### PR TITLE
Declare yarn packageManager in package metadata

### DIFF
--- a/.changeset/mean-oranges-wash.md
+++ b/.changeset/mean-oranges-wash.md
@@ -1,0 +1,5 @@
+---
+'@spritz-finance/api-client': patch
+---
+
+Declare the package manager version in package metadata.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@spritz-finance/api-client",
     "version": "0.4.27",
+    "packageManager": "yarn@1.22.22",
     "description": "Typescript library for interacting with the Spritz Finance API",
     "type": "module",
     "main": "dist/spritz-api-client.cjs",


### PR DESCRIPTION
## Summary
- declare the Yarn version in published package metadata
- add a patch changeset so the new release flow can be exercised end-to-end

## Validation
- yarn agent:check