### PR TITLE
Add HMAC request stamping for REST API auth

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -6,6 +6,7 @@ import { validatePositiveInteger } from '../utils/validatePositiveInteger'
 import { APIConnectionError, APIConnectionTimeoutError, APIError, SpritzApiError } from './error'
 import { gracefulParseJSON } from '../utils/json'
 import { validateGraphQLQuery, sanitizeGraphQLVariables } from '../utils/graphqlSecurity'
+import { stampRequest } from './hmac'
 
 type GraphQLVariables = Record<string, unknown>
 
@@ -49,20 +50,24 @@ export class SpritzClient {
     private timeout: number
     private apiKey: string | undefined
     private integrationKey: string | undefined
+    private integratorSecret: string | undefined
 
     constructor({
         environment,
         timeout = 300000, // 5 minutes
         apiKey,
         integrationKey,
+        integratorSecret,
     }: {
         environment: Environment
         timeout?: number | undefined
         integrationKey: string | undefined
+        integratorSecret: string | undefined
         apiKey: string | undefined
     }) {
         this.apiKey = apiKey
         this.integrationKey = integrationKey
+        this.integratorSecret = integratorSecret
         this.baseGraphURL = config[environment].graphEndpoint
         this.baseRestURL = config[environment].baseEndpoint
         this.baseRestApiURL = config[environment].restEndpoint
@@ -118,15 +123,18 @@ export class SpritzClient {
         method,
         path,
         body = undefined,
+        query,
     }: {
         method: HTTPMethod
         path: string
         body?: Request | undefined
+        query?: Record<string, string | number | boolean | undefined>
     }) {
         return this.sendRestApiRequest({
             method,
             path,
             body,
+            query,
         })
             .then((res) => parseAPIResponse<Response>(res))
             .then(({ response }) => response)
@@ -160,12 +168,26 @@ export class SpritzClient {
         method,
         path,
         body,
+        query,
     }: {
         method: HTTPMethod
         path: string
         body: GraphQLVariables | undefined
+        query?: Record<string, string | number | boolean | undefined>
     }) {
-        const { url, req, timeout } = this.buildRestRequest(method, path, body, this.baseRestApiURL)
+        const { url, req, timeout } = this.buildRestRequest(method, path, body, this.baseRestApiURL, query)
+
+        if (this.integrationKey && this.integratorSecret) {
+            const stamped = await stampRequest(
+                this.integrationKey,
+                this.integratorSecret,
+                method,
+                url,
+                (req.body as string | undefined) ?? null,
+            )
+            req.headers = { ...(req.headers as Record<string, string>), ...stamped }
+        }
+
         return this.sendHTTPRequest({ url, req, timeout })
     }
 
@@ -268,7 +290,8 @@ export class SpritzClient {
         method: HTTPMethod,
         path: string,
         reqBody?: GraphQLVariables | null,
-        baseURL?: string
+        baseURL?: string,
+        query?: Record<string, string | number | boolean | undefined>,
     ) {
         const body = reqBody ? JSON.stringify(reqBody, null, 2) : null
         const contentLength = this.calculateContentLength(body)
@@ -291,9 +314,19 @@ export class SpritzClient {
         }
 
         const base = baseURL ?? this.baseRestURL
+        const normalizedPath = path.startsWith('/') ? path : '/' + path
+        const url = new URL(normalizedPath, base)
+
+        if (query) {
+            for (const [key, value] of Object.entries(query)) {
+                if (value !== undefined) {
+                    url.searchParams.set(key, String(value))
+                }
+            }
+        }
 
         return {
-            url: `${base}${path.startsWith('/') ? path : '/' + path}`,
+            url: url.toString(),
             req,
             timeout,
         }

--- a/src/lib/hmac.test.ts
+++ b/src/lib/hmac.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+    canonicalizeQueryString,
+    buildPathWithQuery,
+    generateHmacSignature,
+    stampRequest,
+} from './hmac'
+
+describe('HMAC Request Stamping', () => {
+    const testSecret = 'test-secret-key-12345'
+    const testRequest = {
+        method: 'POST',
+        path: '/v1/transactions',
+        body: '{"amount":100}',
+    }
+
+    describe('canonicalizeQueryString', () => {
+        it('returns empty string for URL without query params', () => {
+            const url = new URL('https://api.example.com/v1/users/me')
+            expect(canonicalizeQueryString(url)).toBe('')
+        })
+
+        it('sorts params alphabetically by key', () => {
+            const url = new URL(
+                'https://api.example.com/v1/on-ramps?token=USDC&limit=20&network=ethereum',
+            )
+            expect(canonicalizeQueryString(url)).toBe('limit=20&network=ethereum&token=USDC')
+        })
+
+        it('URL-encodes special characters', () => {
+            const url = new URL(
+                'https://api.example.com/v1/test?filter=a+b&query=hello%26world',
+            )
+            expect(canonicalizeQueryString(url)).toBe('filter=a%20b&query=hello%26world')
+        })
+
+        it('handles single param', () => {
+            const url = new URL('https://api.example.com/v1/on-ramps?limit=20')
+            expect(canonicalizeQueryString(url)).toBe('limit=20')
+        })
+
+        it('handles empty value', () => {
+            const url = new URL('https://api.example.com/v1/test?key=')
+            expect(canonicalizeQueryString(url)).toBe('key=')
+        })
+
+        it('produces consistent output regardless of param order', () => {
+            const url1 = new URL(
+                'https://api.example.com/v1/on-ramps?network=ethereum&token=USDC&limit=20',
+            )
+            const url2 = new URL(
+                'https://api.example.com/v1/on-ramps?limit=20&token=USDC&network=ethereum',
+            )
+            expect(canonicalizeQueryString(url1)).toBe(canonicalizeQueryString(url2))
+        })
+    })
+
+    describe('buildPathWithQuery', () => {
+        it('returns just path for URL without query params', () => {
+            const url = new URL('https://api.example.com/v1/users/me')
+            expect(buildPathWithQuery(url)).toBe('/v1/users/me')
+        })
+
+        it('returns path with canonicalized query', () => {
+            const url = new URL(
+                'https://api.example.com/v1/on-ramps?token=USDC&limit=20&network=ethereum',
+            )
+            expect(buildPathWithQuery(url)).toBe(
+                '/v1/on-ramps?limit=20&network=ethereum&token=USDC',
+            )
+        })
+
+        it('produces same output regardless of query param order', () => {
+            const url1 = new URL(
+                'https://api.example.com/v1/on-ramps?network=ethereum&token=USDC&limit=20',
+            )
+            const url2 = new URL(
+                'https://api.example.com/v1/on-ramps?limit=20&token=USDC&network=ethereum',
+            )
+            expect(buildPathWithQuery(url1)).toBe(buildPathWithQuery(url2))
+        })
+    })
+
+    describe('generateHmacSignature', () => {
+        it('generates a signature with sha256= prefix', async () => {
+            const signature = await generateHmacSignature(testSecret, Date.now(), testRequest)
+            expect(signature).toMatch(/^sha256=[0-9a-f]{64}$/)
+        })
+
+        it('generates consistent signatures for same inputs', async () => {
+            const timestamp = 1700000000000
+            const sig1 = await generateHmacSignature(testSecret, timestamp, testRequest)
+            const sig2 = await generateHmacSignature(testSecret, timestamp, testRequest)
+            expect(sig1).toBe(sig2)
+        })
+
+        it('generates different signatures for different timestamps', async () => {
+            const sig1 = await generateHmacSignature(testSecret, 1700000000000, testRequest)
+            const sig2 = await generateHmacSignature(testSecret, 1700000000001, testRequest)
+            expect(sig1).not.toBe(sig2)
+        })
+
+        it('generates different signatures for different secrets', async () => {
+            const timestamp = 1700000000000
+            const sig1 = await generateHmacSignature('secret1', timestamp, testRequest)
+            const sig2 = await generateHmacSignature('secret2', timestamp, testRequest)
+            expect(sig1).not.toBe(sig2)
+        })
+
+        it('generates different signatures for different bodies', async () => {
+            const timestamp = 1700000000000
+            const sig1 = await generateHmacSignature(testSecret, timestamp, {
+                ...testRequest,
+                body: '{"amount":100}',
+            })
+            const sig2 = await generateHmacSignature(testSecret, timestamp, {
+                ...testRequest,
+                body: '{"amount":200}',
+            })
+            expect(sig1).not.toBe(sig2)
+        })
+
+        it('handles requests without body', async () => {
+            const signature = await generateHmacSignature(testSecret, Date.now(), {
+                method: 'GET',
+                path: '/v1/users',
+            })
+            expect(signature).toMatch(/^sha256=[0-9a-f]{64}$/)
+        })
+
+        it('normalizes HTTP method to uppercase', async () => {
+            const timestamp = 1700000000000
+            const sig1 = await generateHmacSignature(testSecret, timestamp, {
+                method: 'post',
+                path: '/v1/test',
+            })
+            const sig2 = await generateHmacSignature(testSecret, timestamp, {
+                method: 'POST',
+                path: '/v1/test',
+            })
+            expect(sig1).toBe(sig2)
+        })
+
+        it('includes canonicalized query string in signature', async () => {
+            const timestamp = 1700000000000
+            const url = new URL(
+                'https://api.example.com/v1/on-ramps?token=USDC&limit=20&network=ethereum',
+            )
+            const sig = await generateHmacSignature(testSecret, timestamp, {
+                method: 'GET',
+                path: buildPathWithQuery(url),
+            })
+            expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/)
+        })
+
+        it('generates same signature regardless of query param order', async () => {
+            const timestamp = 1700000000000
+            const url1 = new URL(
+                'https://api.example.com/v1/on-ramps?network=ethereum&token=USDC&limit=20',
+            )
+            const url2 = new URL(
+                'https://api.example.com/v1/on-ramps?limit=20&token=USDC&network=ethereum',
+            )
+
+            const sig1 = await generateHmacSignature(testSecret, timestamp, {
+                method: 'GET',
+                path: buildPathWithQuery(url1),
+            })
+            const sig2 = await generateHmacSignature(testSecret, timestamp, {
+                method: 'GET',
+                path: buildPathWithQuery(url2),
+            })
+            expect(sig1).toBe(sig2)
+        })
+
+        it('generates different signatures when query params differ', async () => {
+            const timestamp = 1700000000000
+            const sigWithout = await generateHmacSignature(testSecret, timestamp, {
+                method: 'GET',
+                path: '/v1/on-ramps',
+            })
+            const url = new URL('https://api.example.com/v1/on-ramps?limit=20')
+            const sigWith = await generateHmacSignature(testSecret, timestamp, {
+                method: 'GET',
+                path: buildPathWithQuery(url),
+            })
+            expect(sigWithout).not.toBe(sigWith)
+        })
+    })
+
+    describe('stampRequest', () => {
+        it('returns all required HMAC headers', async () => {
+            const headers = await stampRequest(
+                'int_abc123',
+                testSecret,
+                'POST',
+                'https://platform.spritz.finance/v1/transactions',
+                '{"amount":100}',
+            )
+
+            expect(headers).toHaveProperty('X-Integrator-Key', 'int_abc123')
+            expect(headers).toHaveProperty('X-Signature')
+            expect(headers).toHaveProperty('X-Timestamp')
+            expect(headers['X-Signature']).toMatch(/^sha256=[0-9a-f]{64}$/)
+            expect(Number(headers['X-Timestamp'])).toBeGreaterThan(0)
+        })
+
+        it('uses current timestamp', async () => {
+            const before = Date.now()
+            const headers = await stampRequest(
+                'int_abc123',
+                testSecret,
+                'GET',
+                'https://platform.spritz.finance/v1/users/me',
+            )
+            const after = Date.now()
+            const ts = Number(headers['X-Timestamp'])
+            expect(ts).toBeGreaterThanOrEqual(before)
+            expect(ts).toBeLessThanOrEqual(after)
+        })
+
+        it('canonicalizes query params in URL', async () => {
+            vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
+
+            const headers1 = await stampRequest(
+                'int_abc123',
+                testSecret,
+                'GET',
+                'https://platform.spritz.finance/v1/on-ramps?token=USDC&limit=20',
+            )
+            const headers2 = await stampRequest(
+                'int_abc123',
+                testSecret,
+                'GET',
+                'https://platform.spritz.finance/v1/on-ramps?limit=20&token=USDC',
+            )
+
+            expect(headers1['X-Signature']).toBe(headers2['X-Signature'])
+
+            vi.restoreAllMocks()
+        })
+
+        it('handles null body same as undefined', async () => {
+            vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
+
+            const headers1 = await stampRequest(
+                'int_abc123',
+                testSecret,
+                'GET',
+                'https://platform.spritz.finance/v1/users/me',
+                null,
+            )
+            const headers2 = await stampRequest(
+                'int_abc123',
+                testSecret,
+                'GET',
+                'https://platform.spritz.finance/v1/users/me',
+            )
+
+            expect(headers1['X-Signature']).toBe(headers2['X-Signature'])
+
+            vi.restoreAllMocks()
+        })
+    })
+
+    describe('cross-compatibility with platform server', () => {
+        // These tests verify that the Web Crypto implementation produces
+        // the same payload format as the platform's Node crypto implementation.
+        // Payload: `{timestamp}.{METHOD}.{path}.{bodyHash}`
+
+        it('produces correct payload structure for POST with body', async () => {
+            const timestamp = 1700000000000
+            // Two calls with same inputs must produce identical signatures,
+            // confirming deterministic payload construction
+            const sig1 = await generateHmacSignature(testSecret, timestamp, {
+                method: 'POST',
+                path: '/v1/transactions',
+                body: '{"amount":100}',
+            })
+            const sig2 = await generateHmacSignature(testSecret, timestamp, {
+                method: 'POST',
+                path: '/v1/transactions',
+                body: '{"amount":100}',
+            })
+            expect(sig1).toBe(sig2)
+        })
+
+        it('produces correct payload structure for GET without body', async () => {
+            const timestamp = 1700000000000
+            const sig = await generateHmacSignature(testSecret, timestamp, {
+                method: 'GET',
+                path: '/v1/users/me',
+            })
+            // Empty body hash should be empty string in payload
+            expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/)
+        })
+    })
+})

--- a/src/lib/hmac.test.ts
+++ b/src/lib/hmac.test.ts
@@ -264,35 +264,42 @@ describe('HMAC Request Stamping', () => {
     })
 
     describe('cross-compatibility with platform server', () => {
-        // These tests verify that the Web Crypto implementation produces
-        // the same payload format as the platform's Node crypto implementation.
-        // Payload: `{timestamp}.{METHOD}.{path}.{bodyHash}`
+        // Golden test vectors computed using the platform's Node crypto implementation:
+        //   crypto.createHmac('sha256', secret).update(payload).digest('hex')
+        // Payload format: `{timestamp}.{METHOD}.{path}.{bodyHash}`
 
-        it('produces correct payload structure for POST with body', async () => {
-            const timestamp = 1700000000000
-            // Two calls with same inputs must produce identical signatures,
-            // confirming deterministic payload construction
-            const sig1 = await generateHmacSignature(testSecret, timestamp, {
+        it('matches platform signature for POST with body', async () => {
+            const sig = await generateHmacSignature(testSecret, 1700000000000, {
                 method: 'POST',
                 path: '/v1/transactions',
                 body: '{"amount":100}',
             })
-            const sig2 = await generateHmacSignature(testSecret, timestamp, {
-                method: 'POST',
-                path: '/v1/transactions',
-                body: '{"amount":100}',
-            })
-            expect(sig1).toBe(sig2)
+            expect(sig).toBe(
+                'sha256=12dcf2a7647146ce08a465349ab03f992d8a18542cd576d40a9eb8e2958d4b9f',
+            )
         })
 
-        it('produces correct payload structure for GET without body', async () => {
-            const timestamp = 1700000000000
-            const sig = await generateHmacSignature(testSecret, timestamp, {
+        it('matches platform signature for GET without body', async () => {
+            const sig = await generateHmacSignature(testSecret, 1700000000000, {
                 method: 'GET',
                 path: '/v1/users/me',
             })
-            // Empty body hash should be empty string in payload
-            expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/)
+            expect(sig).toBe(
+                'sha256=147ecf7209d3d91ca62d3cc190473954120d305b85c007b50976d4fe88551c52',
+            )
+        })
+
+        it('matches platform signature for GET with canonicalized query params', async () => {
+            const url = new URL(
+                'https://api.example.com/v1/on-ramps?token=USDC&limit=20&network=ethereum',
+            )
+            const sig = await generateHmacSignature(testSecret, 1700000000000, {
+                method: 'GET',
+                path: buildPathWithQuery(url),
+            })
+            expect(sig).toBe(
+                'sha256=77cc4cdebcc5256d682fb3974346c15e84b289f6a4bb454adaa7f9495d3bbc55',
+            )
         })
     })
 })

--- a/src/lib/hmac.ts
+++ b/src/lib/hmac.ts
@@ -1,0 +1,108 @@
+const SIGNATURE_PREFIX = 'sha256='
+
+function hexEncode(buffer: ArrayBuffer): string {
+    return Array.from(new Uint8Array(buffer))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('')
+}
+
+async function sha256Hex(data: string): Promise<string> {
+    const encoded = new TextEncoder().encode(data)
+    const hash = await crypto.subtle.digest('SHA-256', encoded)
+    return hexEncode(hash)
+}
+
+async function hmacSha256Hex(secret: string, data: string): Promise<string> {
+    const encoder = new TextEncoder()
+    const key = await crypto.subtle.importKey(
+        'raw',
+        encoder.encode(secret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign'],
+    )
+    const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(data))
+    return hexEncode(signature)
+}
+
+/**
+ * Canonicalize query string for HMAC signature.
+ * Params are sorted alphabetically by key and URL-encoded.
+ */
+export function canonicalizeQueryString(url: URL): string {
+    const params = url.searchParams
+    if ([...params].length === 0) return ''
+
+    return [...params.keys()]
+        .sort()
+        .map((key) => {
+            const value = params.get(key) ?? ''
+            return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+        })
+        .join('&')
+}
+
+/**
+ * Build path with canonicalized query string for HMAC signature.
+ */
+export function buildPathWithQuery(url: URL): string {
+    const canonicalQuery = canonicalizeQueryString(url)
+    if (canonicalQuery === '') return url.pathname
+    return `${url.pathname}?${canonicalQuery}`
+}
+
+/**
+ * Generate HMAC-SHA256 signature for a request.
+ *
+ * Payload format: `{timestamp}.{METHOD}.{pathWithQuery}.{bodyHash}`
+ * - Body is SHA256 hashed; empty string if no body
+ * - Method is normalized to uppercase
+ * - Path should include canonicalized query string (use buildPathWithQuery)
+ */
+export async function generateHmacSignature(
+    secret: string,
+    timestamp: number,
+    request: { method: string; path: string; body?: string | null },
+): Promise<string> {
+    const bodyHash = request.body ? await sha256Hex(request.body) : ''
+    const payload = `${timestamp}.${request.method.toUpperCase()}.${request.path}.${bodyHash}`
+    const signature = await hmacSha256Hex(secret, payload)
+    return `${SIGNATURE_PREFIX}${signature}`
+}
+
+export interface StampedHeaders {
+    'X-Integrator-Key': string
+    'X-Signature': string
+    'X-Timestamp': string
+}
+
+/**
+ * Stamp a REST API request with HMAC signature headers.
+ *
+ * Returns the three headers required for integrator HMAC auth:
+ * - X-Integrator-Key: the integrator's API key
+ * - X-Signature: sha256={hmac hex digest}
+ * - X-Timestamp: Unix milliseconds
+ */
+export async function stampRequest(
+    integratorKey: string,
+    integratorSecret: string,
+    method: string,
+    url: string,
+    body?: string | null,
+): Promise<StampedHeaders> {
+    const parsedUrl = new URL(url)
+    const path = buildPathWithQuery(parsedUrl)
+    const timestamp = Date.now()
+    const signature = await generateHmacSignature(integratorSecret, timestamp, {
+        method,
+        path,
+        body,
+    })
+
+    return {
+        'X-Integrator-Key': integratorKey,
+        'X-Signature': signature,
+        'X-Timestamp': String(timestamp),
+    }
+}

--- a/src/spritzApiClient.ts
+++ b/src/spritzApiClient.ts
@@ -81,6 +81,11 @@ export class SpritzApiClient {
                 'The integrationKey or apiKey variable appears to be missing or empty. Please ensure you provide it, or when initializing the SpritzApiClient, opt for the integratorKey option.'
             )
         }
+        if (integratorSecret && !integrationKey) {
+            throw new Error(
+                'integratorSecret requires integrationKey to be provided. Both are needed for HMAC-signed REST API requests.'
+            )
+        }
         this.environment = environment
         this.apiKey = apiKey
         this.integrationKey = integrationKey

--- a/src/spritzApiClient.ts
+++ b/src/spritzApiClient.ts
@@ -25,6 +25,12 @@ export type ClientOptions = {
     integrationKey?: string
 
     /**
+     * The integrator's HMAC secret used to sign REST API requests.
+     * Required for authenticated REST API calls to the platform.
+     */
+    integratorSecret?: string
+
+    /**
      * The client will wait up to a specified duration (in milliseconds)
      * for a response from the server before considering a single request as timed out.
      *
@@ -47,6 +53,7 @@ export class SpritzApiClient {
     private environment: Environment
     private apiKey: string | undefined
     private integrationKey: string | undefined
+    private integratorSecret: string | undefined
 
     private client: SpritzClient
     public user: UserService
@@ -66,7 +73,8 @@ export class SpritzApiClient {
         environment: Environment,
         apiKey?: string,
         integrationKey?: string,
-        dangerouslyAllowBrowser?: boolean
+        integratorSecret?: string,
+        dangerouslyAllowBrowser?: boolean,
     ) {
         if (apiKey === undefined && integrationKey === undefined) {
             throw new Error(
@@ -76,6 +84,7 @@ export class SpritzApiClient {
         this.environment = environment
         this.apiKey = apiKey
         this.integrationKey = integrationKey
+        this.integratorSecret = integratorSecret
 
         if (!dangerouslyAllowBrowser && isRunningInBrowser()) {
             throw new Error(
@@ -88,13 +97,15 @@ export class SpritzApiClient {
         environment = Environment.Sandbox,
         apiKey,
         integrationKey,
+        integratorSecret,
         dangerouslyAllowBrowser = false,
     }: ClientOptions) {
         const client = new SpritzApiClient(
             environment,
             apiKey,
             integrationKey,
-            dangerouslyAllowBrowser
+            integratorSecret,
+            dangerouslyAllowBrowser,
         )
         client.init()
         return client
@@ -105,6 +116,7 @@ export class SpritzApiClient {
             environment: this.environment,
             apiKey: this.apiKey,
             integrationKey: this.integrationKey,
+            integratorSecret: this.integratorSecret,
         })
         this.user = new UserService(this.client)
         this.bankAccount = new BankAccountService(this.client)


### PR DESCRIPTION
## Summary
- Add `integratorSecret` client option and HMAC-SHA256 request stamper for REST API calls
- REST API requests are signed with `X-Integrator-Key`, `X-Signature`, and `X-Timestamp` headers matching the platform's integrator HMAC auth spec
- Add query parameter support to `restApi()` with canonical sorting for signature stability
- Uses Web Crypto API (`crypto.subtle`) — works in Node 20+ and browsers, no new dependencies

## Test plan
- [x] 25 new tests covering canonicalization, signature generation, stamping, and cross-compat
- [x] All existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)