### PR TITLE
Add sandbox scripts for API testing with REST passthrough

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Sandbox credentials for scripts/sandbox/
+SPRITZ_INTEGRATION_KEY=
+SPRITZ_INTEGRATOR_SECRET=
+SPRITZ_API_KEY=

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "rollup-plugin-dts": "6.2.1",
         "rollup-plugin-esbuild": "6.2.1",
         "tslib": "2.8.1",
+        "tsx": "^4.21.0",
         "typescript": "5.8.3",
         "viem": "^2.31.7",
         "vite-plugin-graphql-loader": "^4.0.4",

--- a/scripts/sandbox/bank-account-lifecycle.ts
+++ b/scripts/sandbox/bank-account-lifecycle.ts
@@ -1,0 +1,65 @@
+/**
+ * Create a US bank account via REST API, verify it exists, then delete it.
+ *
+ * Usage:
+ *   ./scripts/sandbox/run.sh bank-account-lifecycle
+ *
+ * Requires SPRITZ_API_KEY in .env (user must be KYC-verified)
+ */
+import { createClient } from './client'
+import { requireEnv } from './env'
+
+async function main() {
+    requireEnv('SPRITZ_API_KEY')
+    const client = createClient()
+
+    // Create via REST API (HMAC-signed POST with body)
+    console.log('=== Creating US bank account (REST API) ===')
+    const created = await client.restApi<{ id: string }>({
+        method: 'post',
+        path: '/v1/bank-accounts/',
+        body: {
+            type: 'us',
+            ownership: 'personal',
+            routingNumber: '021000021',
+            accountNumber: '123456789',
+            accountSubtype: 'checking',
+            label: 'SDK Test Account',
+        },
+    })
+    console.log('Created:', created)
+    const accountId = created.id
+
+    // List via GraphQL to confirm it exists
+    console.log('\n=== Verifying via GraphQL ===')
+    const accounts = await client.bankAccount.list()
+    const found = accounts.find((a) => a.id === accountId)
+    console.log(found ? `Found: ${found.id} — ${found.name} [${found.type}]` : 'NOT FOUND')
+
+    // List via REST API to confirm
+    console.log('\n=== Verifying via REST API ===')
+    const restAccounts = await client.restApi<unknown[]>({
+        method: 'get',
+        path: '/v1/bank-accounts/',
+    })
+    console.log(`REST API returned ${(restAccounts as unknown[]).length} account(s)`)
+
+    // Delete via REST API (HMAC-signed DELETE, no body)
+    console.log(`\n=== Deleting ${accountId} (REST API) ===`)
+    await client.restApi({
+        method: 'delete',
+        path: `/v1/bank-accounts/${accountId}`,
+    })
+    console.log('Deleted')
+
+    // Verify deletion
+    console.log('\n=== Verifying deletion (GraphQL) ===')
+    const afterDelete = await client.bankAccount.list()
+    const stillExists = afterDelete.find((a) => a.id === accountId)
+    console.log(stillExists ? 'STILL EXISTS (unexpected)' : 'Confirmed deleted')
+}
+
+main().catch((err) => {
+    console.error('Failed:', err.message ?? err)
+    process.exit(1)
+})

--- a/scripts/sandbox/client.ts
+++ b/scripts/sandbox/client.ts
@@ -1,0 +1,15 @@
+import { SpritzApiClient, Environment } from '../../dist/spritz-api-client.mjs'
+import { requireEnv, optionalEnv } from './env'
+
+export function createClient(apiKey?: string) {
+    const integrationKey = requireEnv('SPRITZ_INTEGRATION_KEY')
+    const integratorSecret = requireEnv('SPRITZ_INTEGRATOR_SECRET')
+    const key = apiKey ?? optionalEnv('SPRITZ_API_KEY')
+
+    return SpritzApiClient.initialize({
+        environment: Environment.Sandbox,
+        integrationKey,
+        integratorSecret,
+        apiKey: key,
+    })
+}

--- a/scripts/sandbox/env.ts
+++ b/scripts/sandbox/env.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config'
+
+export function requireEnv(name: string): string {
+    const value = process.env[name]
+    if (!value) {
+        console.error(`Missing required env var: ${name}`)
+        console.error('Create a .env file with your sandbox credentials. See .env.example')
+        process.exit(1)
+    }
+    return value
+}
+
+export function optionalEnv(name: string): string | undefined {
+    return process.env[name] || undefined
+}

--- a/scripts/sandbox/get-payment-limits.ts
+++ b/scripts/sandbox/get-payment-limits.ts
@@ -1,0 +1,37 @@
+/**
+ * Get payment limits for a bank account via the service layer (REST under the hood).
+ *
+ * Usage:
+ *   ./scripts/sandbox/run.sh get-payment-limits <accountId>
+ *
+ * Requires SPRITZ_API_KEY in .env
+ */
+import { createClient } from './client'
+import { requireEnv } from './env'
+
+async function main() {
+    const accountId = process.argv[2]
+    if (!accountId) {
+        console.error('Usage: get-payment-limits <accountId>')
+        console.error('Run list-bank-accounts first to get an account ID')
+        process.exit(1)
+    }
+
+    requireEnv('SPRITZ_API_KEY')
+    const client = createClient()
+
+    console.log(`=== Payment Limits for ${accountId} ===`)
+    const limits = await client.payment.getPaymentLimits(accountId)
+
+    if (!limits) {
+        console.log('No limits returned (account may not exist)')
+        return
+    }
+
+    console.log(JSON.stringify(limits, null, 2))
+}
+
+main().catch((err) => {
+    console.error('Failed:', err.message ?? err)
+    process.exit(1)
+})

--- a/scripts/sandbox/get-user.ts
+++ b/scripts/sandbox/get-user.ts
@@ -1,0 +1,24 @@
+/**
+ * Fetch the current user profile via GraphQL.
+ *
+ * Usage:
+ *   npx tsx scripts/sandbox/get-user.ts
+ *
+ * Requires SPRITZ_API_KEY in .env
+ */
+import { createClient } from './client'
+import { requireEnv } from './env'
+
+async function main() {
+    requireEnv('SPRITZ_API_KEY')
+    const client = createClient()
+
+    console.log('Fetching current user (GraphQL)...')
+    const user = await client.user.getCurrentUser()
+    console.log(JSON.stringify(user, null, 2))
+}
+
+main().catch((err) => {
+    console.error('Failed:', err.message ?? err)
+    process.exit(1)
+})

--- a/scripts/sandbox/list-bank-accounts.ts
+++ b/scripts/sandbox/list-bank-accounts.ts
@@ -1,0 +1,36 @@
+/**
+ * List bank accounts via both GraphQL (service) and REST API (HMAC-signed).
+ *
+ * Usage:
+ *   ./scripts/sandbox/run.sh list-bank-accounts
+ *
+ * Requires SPRITZ_API_KEY in .env
+ */
+import { createClient } from './client'
+import { requireEnv } from './env'
+
+async function main() {
+    requireEnv('SPRITZ_API_KEY')
+    const client = createClient()
+
+    // GraphQL path
+    console.log('=== Bank Accounts (GraphQL) ===')
+    const graphqlAccounts = await client.bankAccount.list()
+    console.log(`Found ${graphqlAccounts.length} account(s)`)
+    for (const acct of graphqlAccounts) {
+        console.log(`  ${acct.id} — ${acct.name ?? '(unnamed)'} [${acct.type}]`)
+    }
+
+    // REST API path (HMAC-signed)
+    console.log('\n=== Bank Accounts (REST API) ===')
+    const restAccounts = await client.restApi({
+        method: 'get',
+        path: '/v1/bank-accounts/',
+    })
+    console.log(JSON.stringify(restAccounts, null, 2))
+}
+
+main().catch((err) => {
+    console.error('Failed:', err.message ?? err)
+    process.exit(1)
+})

--- a/scripts/sandbox/list-off-ramps.ts
+++ b/scripts/sandbox/list-off-ramps.ts
@@ -1,0 +1,46 @@
+/**
+ * List off-ramps via the REST API (HMAC-signed, with query params).
+ *
+ * Usage:
+ *   ./scripts/sandbox/run.sh list-off-ramps
+ *   ./scripts/sandbox/run.sh list-off-ramps --status=completed
+ *   ./scripts/sandbox/run.sh list-off-ramps --chain=ethereum --limit=5
+ *
+ * Requires SPRITZ_API_KEY in .env
+ */
+import { createClient } from './client'
+import { requireEnv } from './env'
+
+function parseArgs(args: string[]): Record<string, string> {
+    const result: Record<string, string> = {}
+    for (const arg of args) {
+        const match = arg.match(/^--(\w+)=(.+)$/)
+        if (match) {
+            result[match[1]!] = match[2]!
+        }
+    }
+    return result
+}
+
+async function main() {
+    requireEnv('SPRITZ_API_KEY')
+    const query = parseArgs(process.argv.slice(2))
+
+    console.log('=== Off-Ramps (REST API) ===')
+    if (Object.keys(query).length > 0) {
+        console.log('Filters:', query)
+    }
+
+    const client = createClient()
+    const offRamps = await client.restApi({
+        method: 'get',
+        path: '/v1/off-ramps/',
+        query,
+    })
+    console.log(JSON.stringify(offRamps, null, 2))
+}
+
+main().catch((err) => {
+    console.error('Failed:', err.message ?? err)
+    process.exit(1)
+})

--- a/scripts/sandbox/list-on-ramps.ts
+++ b/scripts/sandbox/list-on-ramps.ts
@@ -1,0 +1,45 @@
+/**
+ * List on-ramps via the REST API (HMAC-signed, with query params).
+ *
+ * Usage:
+ *   ./scripts/sandbox/run.sh list-on-ramps
+ *   ./scripts/sandbox/run.sh list-on-ramps --network=ethereum --token=USDC
+ *
+ * Requires SPRITZ_API_KEY in .env
+ */
+import { createClient } from './client'
+import { requireEnv } from './env'
+
+function parseArgs(args: string[]): Record<string, string> {
+    const result: Record<string, string> = {}
+    for (const arg of args) {
+        const match = arg.match(/^--(\w+)=(.+)$/)
+        if (match) {
+            result[match[1]!] = match[2]!
+        }
+    }
+    return result
+}
+
+async function main() {
+    requireEnv('SPRITZ_API_KEY')
+    const query = parseArgs(process.argv.slice(2))
+
+    console.log('=== On-Ramps (REST API) ===')
+    if (Object.keys(query).length > 0) {
+        console.log('Filters:', query)
+    }
+
+    const client = createClient()
+    const onRamps = await client.restApi({
+        method: 'get',
+        path: '/v1/on-ramps/',
+        query,
+    })
+    console.log(JSON.stringify(onRamps, null, 2))
+}
+
+main().catch((err) => {
+    console.error('Failed:', err.message ?? err)
+    process.exit(1)
+})

--- a/scripts/sandbox/run.sh
+++ b/scripts/sandbox/run.sh
@@ -13,8 +13,8 @@ SCRIPT="${1:?Usage: run.sh <script-name> [args...]}"
 shift
 
 echo "Building..."
-yarn build --silent 2>/dev/null
+yarn build --silent
 echo "Build OK"
 echo ""
 
-exec npx tsx "scripts/sandbox/${SCRIPT}.ts" "$@"
+exec yarn tsx "scripts/sandbox/${SCRIPT}.ts" "$@"

--- a/scripts/sandbox/run.sh
+++ b/scripts/sandbox/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run a sandbox script with a fresh build.
+#
+# Usage:
+#   ./scripts/sandbox/run.sh setup-user [args...]
+#   ./scripts/sandbox/run.sh list-bank-accounts
+#   ./scripts/sandbox/run.sh list-off-ramps
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+SCRIPT="${1:?Usage: run.sh <script-name> [args...]}"
+shift
+
+echo "Building..."
+yarn build --silent 2>/dev/null
+echo "Build OK"
+echo ""
+
+exec npx tsx "scripts/sandbox/${SCRIPT}.ts" "$@"

--- a/scripts/sandbox/setup-user.ts
+++ b/scripts/sandbox/setup-user.ts
@@ -1,0 +1,42 @@
+/**
+ * Create a sandbox user, bypass KYC, and print the API key.
+ *
+ * Usage:
+ *   ./scripts/sandbox/run.sh setup-user [email]
+ *
+ * If no email is provided, generates one using a timestamp.
+ */
+import { createClient } from './client'
+
+const email = process.argv[2] ?? `sandbox+${Date.now()}@spritz.finance`
+
+async function main() {
+    console.log(`Creating user: ${email}`)
+
+    const client = createClient()
+    const user = await client.user.create({ email })
+    console.log(`User created: ${user.userId}`)
+    console.log(`API key: ${user.apiKey}`)
+
+    // Bypass KYC via REST API (HMAC-signed)
+    console.log('\nBypassing KYC...')
+    client.setApiKey(user.apiKey)
+    await client.restApi({
+        method: 'post',
+        path: '/v1/sandbox/bypass-kyc',
+        body: { country: 'US' },
+    })
+    console.log('KYC bypassed (US)')
+
+    // Verify by fetching user profile
+    const currentUser = await client.user.getCurrentUser()
+    console.log('\nUser profile:')
+    console.log(JSON.stringify(currentUser, null, 2))
+
+    console.log(`\nAdd to .env:\n  SPRITZ_API_KEY=${user.apiKey}`)
+}
+
+main().catch((err) => {
+    console.error('Failed:', err.message ?? err)
+    process.exit(1)
+})

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -185,7 +185,8 @@ export class SpritzClient {
                 url,
                 (req.body as string | undefined) ?? null,
             )
-            req.headers = { ...(req.headers as Record<string, string>), ...stamped }
+            const { 'X-INTEGRATION-KEY': _, ...headers } = req.headers as Record<string, string>
+            req.headers = { ...headers, ...stamped }
         }
 
         return this.sendHTTPRequest({ url, req, timeout })
@@ -293,7 +294,7 @@ export class SpritzClient {
         baseURL?: string,
         query?: Record<string, string | number | boolean | undefined>,
     ) {
-        const body = reqBody ? JSON.stringify(reqBody, null, 2) : null
+        const body = reqBody ? JSON.stringify(reqBody) : null
         const contentLength = this.calculateContentLength(body)
         const timeout = this.timeout
 

--- a/src/spritzApiClient.ts
+++ b/src/spritzApiClient.ts
@@ -137,6 +137,19 @@ export class SpritzApiClient {
         this.webhook = new WebhookService(this.client)
     }
 
+    /**
+     * Make a direct REST API call to the platform.
+     * Requests are HMAC-signed when integratorSecret is configured.
+     */
+    public async restApi<Response, Request extends Record<string, unknown> = Record<string, unknown>>(args: {
+        method: 'get' | 'post' | 'put' | 'patch' | 'delete'
+        path: string
+        body?: Request
+        query?: Record<string, string | number | boolean | undefined>
+    }) {
+        return this.client.restApi<Response, Request>(args)
+    }
+
     setApiKey(_apiKey: string) {
         this.apiKey = _apiKey
         this.init()

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,130 +399,260 @@
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz#164b19122e2ed54f85469df9dea98ddb01d5e79e"
   integrity sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==
 
+"@esbuild/aix-ppc64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz#4c585002f7ad694d38fe0e8cbf5cfd939ccff327"
+  integrity sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==
+
 "@esbuild/android-arm64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz#8f539e7def848f764f6432598e51cc3820fde3a5"
   integrity sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==
+
+"@esbuild/android-arm64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz#7625d0952c3b402d3ede203a16c9f2b78f8a4827"
+  integrity sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==
 
 "@esbuild/android-arm@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.6.tgz#4ceb0f40113e9861169be83e2a670c260dd234ff"
   integrity sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==
 
+"@esbuild/android-arm@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.4.tgz#9a0cf1d12997ec46dddfb32ce67e9bca842381ac"
+  integrity sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==
+
 "@esbuild/android-x64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.6.tgz#ad4f280057622c25fe985c08999443a195dc63a8"
   integrity sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==
+
+"@esbuild/android-x64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.4.tgz#06e1fdc6283fccd6bc6aadd6754afce6cf96f42e"
+  integrity sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==
 
 "@esbuild/darwin-arm64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz#d1f04027396b3d6afc96bacd0d13167dfd9f01f7"
   integrity sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==
 
+"@esbuild/darwin-arm64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz#6c550ee6c0273bcb0fac244478ff727c26755d80"
+  integrity sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==
+
 "@esbuild/darwin-x64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz#2b4a6cedb799f635758d7832d75b23772c8ef68f"
   integrity sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==
+
+"@esbuild/darwin-x64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz#ed7a125e9f25ce0091b9aff783ee943f6ba6cb86"
+  integrity sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==
 
 "@esbuild/freebsd-arm64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz#a26266cc97dd78dc3c3f3d6788b1b83697b1055d"
   integrity sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==
 
+"@esbuild/freebsd-arm64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz#597dc8e7161dba71db4c1656131c1f1e9d7660c6"
+  integrity sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==
+
 "@esbuild/freebsd-x64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz#9feb8e826735c568ebfd94859b22a3fbb6a9bdd2"
   integrity sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==
+
+"@esbuild/freebsd-x64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz#ea171f9f4f00efaa8e9d3fe8baa1b75d757d1b36"
+  integrity sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==
 
 "@esbuild/linux-arm64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz#c07cbed8e249f4c28e7f32781d36fc4695293d28"
   integrity sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==
 
+"@esbuild/linux-arm64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz#e52d57f202369386e6dbcb3370a17a0491ab1464"
+  integrity sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==
+
 "@esbuild/linux-arm@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz#d6e2cd8ef3196468065d41f13fa2a61aaa72644a"
   integrity sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==
+
+"@esbuild/linux-arm@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz#5e0c0b634908adbce0a02cebeba8b3acac263fb6"
+  integrity sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==
 
 "@esbuild/linux-ia32@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz#3e682bd47c4eddcc4b8f1393dfc8222482f17997"
   integrity sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==
 
+"@esbuild/linux-ia32@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz#5f90f01f131652473ec06b038a14c49683e14ec7"
+  integrity sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==
+
 "@esbuild/linux-loong64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz#473f5ea2e52399c08ad4cd6b12e6dbcddd630f05"
   integrity sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==
+
+"@esbuild/linux-loong64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz#63bacffdb99574c9318f9afbd0dd4fff76a837e3"
+  integrity sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==
 
 "@esbuild/linux-mips64el@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz#9960631c9fd61605b0939c19043acf4ef2b51718"
   integrity sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==
 
+"@esbuild/linux-mips64el@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz#c4b6952eca6a8efff67fee3671a3536c8e67b7eb"
+  integrity sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==
+
 "@esbuild/linux-ppc64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz#477cbf8bb04aa034b94f362c32c86b5c31db8d3e"
   integrity sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==
+
+"@esbuild/linux-ppc64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz#6dea67d3d98c6986f1b7769e4f1848e5ae47ad58"
+  integrity sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==
 
 "@esbuild/linux-riscv64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz#bcdb46c8fb8e93aa779e9a0a62cd4ac00dcac626"
   integrity sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==
 
+"@esbuild/linux-riscv64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz#9ad2b4c3c0502c6bada9c81997bb56c597853489"
+  integrity sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==
+
 "@esbuild/linux-s390x@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz#f412cf5fdf0aea849ff51c73fd817c6c0234d46d"
   integrity sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==
+
+"@esbuild/linux-s390x@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz#c43d3cfd073042ca6f5c52bb9bc313ed2066ce28"
+  integrity sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==
 
 "@esbuild/linux-x64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz#d8233c09b5ebc0c855712dc5eeb835a3a3341108"
   integrity sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==
 
+"@esbuild/linux-x64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz#45fa173e0591ac74d80d3cf76704713e14e2a4a6"
+  integrity sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==
+
 "@esbuild/netbsd-arm64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz#f51ae8dd1474172e73cf9cbaf8a38d1c72dd8f1a"
   integrity sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==
+
+"@esbuild/netbsd-arm64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz#366b0ef40cdb986fc751cbdad16e8c25fe1ba879"
+  integrity sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==
 
 "@esbuild/netbsd-x64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz#a267538602c0e50a858cf41dcfe5d8036f8da8e7"
   integrity sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==
 
+"@esbuild/netbsd-x64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz#e985d49a3668fd2044343071d52e1ae815112b3e"
+  integrity sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==
+
 "@esbuild/openbsd-arm64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz#a51be60c425b85c216479b8c344ad0511635f2d2"
   integrity sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==
+
+"@esbuild/openbsd-arm64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz#6fb4ab7b73f7e5572ce5ec9cf91c13ff6dd44842"
+  integrity sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==
 
 "@esbuild/openbsd-x64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz#7e4a743c73f75562e29223ba69d0be6c9c9008da"
   integrity sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==
 
+"@esbuild/openbsd-x64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz#641f052040a0d79843d68898f5791638a026d983"
+  integrity sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==
+
 "@esbuild/openharmony-arm64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz#2087a5028f387879154ebf44bdedfafa17682e5b"
   integrity sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==
+
+"@esbuild/openharmony-arm64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz#fc1d33eac9d81ae0a433b3ed1dd6171a20d4e317"
+  integrity sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==
 
 "@esbuild/sunos-x64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz#56531f861723ea0dc6283a2bb8837304223cb736"
   integrity sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==
 
+"@esbuild/sunos-x64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz#af2cd5ca842d6d057121f66a192d4f797de28f53"
+  integrity sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==
+
 "@esbuild/win32-arm64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz#f4989f033deac6fae323acff58764fa8bc01436e"
   integrity sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==
+
+"@esbuild/win32-arm64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz#78ec7e59bb06404583d4c9511e621db31c760de3"
+  integrity sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==
 
 "@esbuild/win32-ia32@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz#b260e9df71e3939eb33925076d39f63cec7d1525"
   integrity sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==
 
+"@esbuild/win32-ia32@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz#0e616aa488b7ee5d2592ab070ff9ec06a9fddf11"
+  integrity sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==
+
 "@esbuild/win32-x64@0.25.6":
   version "0.25.6"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz#4276edd5c105bc28b11c6a1f76fb9d29d1bd25c1"
   integrity sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==
+
+"@esbuild/win32-x64@0.27.4":
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz#1f7ba71a3d6155d44a6faa8dbe249c62ab3e408c"
+  integrity sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==
 
 "@inquirer/confirm@^5.0.0":
   version "5.1.13"
@@ -2861,6 +2991,38 @@ esbuild@0.25.6, esbuild@^0.25.0:
     "@esbuild/win32-ia32" "0.25.6"
     "@esbuild/win32-x64" "0.25.6"
 
+esbuild@~0.27.0:
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.27.4.tgz#b9591dd7e0ab803a11c9c3b602850403bef22f00"
+  integrity sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.27.4"
+    "@esbuild/android-arm" "0.27.4"
+    "@esbuild/android-arm64" "0.27.4"
+    "@esbuild/android-x64" "0.27.4"
+    "@esbuild/darwin-arm64" "0.27.4"
+    "@esbuild/darwin-x64" "0.27.4"
+    "@esbuild/freebsd-arm64" "0.27.4"
+    "@esbuild/freebsd-x64" "0.27.4"
+    "@esbuild/linux-arm" "0.27.4"
+    "@esbuild/linux-arm64" "0.27.4"
+    "@esbuild/linux-ia32" "0.27.4"
+    "@esbuild/linux-loong64" "0.27.4"
+    "@esbuild/linux-mips64el" "0.27.4"
+    "@esbuild/linux-ppc64" "0.27.4"
+    "@esbuild/linux-riscv64" "0.27.4"
+    "@esbuild/linux-s390x" "0.27.4"
+    "@esbuild/linux-x64" "0.27.4"
+    "@esbuild/netbsd-arm64" "0.27.4"
+    "@esbuild/netbsd-x64" "0.27.4"
+    "@esbuild/openbsd-arm64" "0.27.4"
+    "@esbuild/openbsd-x64" "0.27.4"
+    "@esbuild/openharmony-arm64" "0.27.4"
+    "@esbuild/sunos-x64" "0.27.4"
+    "@esbuild/win32-arm64" "0.27.4"
+    "@esbuild/win32-ia32" "0.27.4"
+    "@esbuild/win32-x64" "0.27.4"
+
 escalade@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
@@ -3200,6 +3362,13 @@ get-tsconfig@^4.10.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.10.1.tgz#d34c1c01f47d65a606c37aa7a177bc3e56ab4b2e"
   integrity sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
+
+get-tsconfig@^4.7.5:
+  version "4.13.7"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.13.7.tgz#b9d8b199b06033ceeea1a93df7ea5765415089bc"
+  integrity sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
@@ -5689,6 +5858,16 @@ tslib@^2.1.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tsx@^4.21.0:
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.21.0.tgz#32aa6cf17481e336f756195e6fe04dae3e6308b1"
+  integrity sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==
+  dependencies:
+    esbuild "~0.27.0"
+    get-tsconfig "^4.7.5"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 tty@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Add .env.example with required sandbox credentials for local script runs
- Introduce sandbox client/env helpers to initialize SpritzApiClient in Sandbox and load env vars via dotenv
- Add runnable scripts to fetch current user, list bank accounts, and query payment limits
- Add REST API passthrough examples (HMAC-signed) for listing bank accounts, on-ramps, and off-ramps with optional query filters
- Include a run.sh helper to execute sandbox scripts against a fresh build