### PR TITLE
Refactor sandbox scripts to use dedicated REST client

### DIFF
--- a/scripts/sandbox/bank-account-lifecycle.ts
+++ b/scripts/sandbox/bank-account-lifecycle.ts
@@ -6,16 +6,17 @@
  *
  * Requires SPRITZ_API_KEY in .env (user must be KYC-verified)
  */
-import { createClient } from './client'
+import { createClient, createRestClient } from './client'
 import { requireEnv } from './env'
 
 async function main() {
-    requireEnv('SPRITZ_API_KEY')
+    const apiKey = requireEnv('SPRITZ_API_KEY')
     const client = createClient()
+    const rest = createRestClient(apiKey)
 
     // Create via REST API (HMAC-signed POST with body)
     console.log('=== Creating US bank account (REST API) ===')
-    const created = await client.restApi<{ id: string }>({
+    const created = await rest.restApi<{ id: string }>({
         method: 'post',
         path: '/v1/bank-accounts/',
         body: {
@@ -38,7 +39,7 @@ async function main() {
 
     // List via REST API to confirm
     console.log('\n=== Verifying via REST API ===')
-    const restAccounts = await client.restApi<unknown[]>({
+    const restAccounts = await rest.restApi<unknown[]>({
         method: 'get',
         path: '/v1/bank-accounts/',
     })
@@ -46,7 +47,7 @@ async function main() {
 
     // Delete via REST API (HMAC-signed DELETE, no body)
     console.log(`\n=== Deleting ${accountId} (REST API) ===`)
-    await client.restApi({
+    await rest.restApi({
         method: 'delete',
         path: `/v1/bank-accounts/${accountId}`,
     })

--- a/scripts/sandbox/client.ts
+++ b/scripts/sandbox/client.ts
@@ -1,20 +1,23 @@
 import { SpritzApiClient, Environment } from '../../dist/spritz-api-client.mjs'
 import { SpritzClient } from '../../src/lib/client'
+import { Environment as SrcEnvironment } from '../../src/env'
 import { requireEnv, optionalEnv } from './env'
+
+function credentials(apiKey?: string) {
+    return {
+        integrationKey: requireEnv('SPRITZ_INTEGRATION_KEY'),
+        integratorSecret: requireEnv('SPRITZ_INTEGRATOR_SECRET'),
+        apiKey: apiKey ?? optionalEnv('SPRITZ_API_KEY'),
+    }
+}
 
 /**
  * High-level client for service methods (GraphQL + typed REST via services).
  */
 export function createClient(apiKey?: string) {
-    const integrationKey = requireEnv('SPRITZ_INTEGRATION_KEY')
-    const integratorSecret = requireEnv('SPRITZ_INTEGRATOR_SECRET')
-    const key = apiKey ?? optionalEnv('SPRITZ_API_KEY')
-
     return SpritzApiClient.initialize({
         environment: Environment.Sandbox,
-        integrationKey,
-        integratorSecret,
-        apiKey: key,
+        ...credentials(apiKey),
     })
 }
 
@@ -23,14 +26,8 @@ export function createClient(apiKey?: string) {
  * Use for endpoints not yet wrapped in a service.
  */
 export function createRestClient(apiKey?: string) {
-    const integrationKey = requireEnv('SPRITZ_INTEGRATION_KEY')
-    const integratorSecret = requireEnv('SPRITZ_INTEGRATOR_SECRET')
-    const key = apiKey ?? optionalEnv('SPRITZ_API_KEY')
-
     return new SpritzClient({
-        environment: 'staging',
-        integrationKey,
-        integratorSecret,
-        apiKey: key,
+        environment: SrcEnvironment.Sandbox,
+        ...credentials(apiKey),
     })
 }

--- a/scripts/sandbox/client.ts
+++ b/scripts/sandbox/client.ts
@@ -1,6 +1,10 @@
 import { SpritzApiClient, Environment } from '../../dist/spritz-api-client.mjs'
+import { SpritzClient } from '../../src/lib/client'
 import { requireEnv, optionalEnv } from './env'
 
+/**
+ * High-level client for service methods (GraphQL + typed REST via services).
+ */
 export function createClient(apiKey?: string) {
     const integrationKey = requireEnv('SPRITZ_INTEGRATION_KEY')
     const integratorSecret = requireEnv('SPRITZ_INTEGRATOR_SECRET')
@@ -8,6 +12,23 @@ export function createClient(apiKey?: string) {
 
     return SpritzApiClient.initialize({
         environment: Environment.Sandbox,
+        integrationKey,
+        integratorSecret,
+        apiKey: key,
+    })
+}
+
+/**
+ * Low-level client for direct REST API calls (HMAC-signed).
+ * Use for endpoints not yet wrapped in a service.
+ */
+export function createRestClient(apiKey?: string) {
+    const integrationKey = requireEnv('SPRITZ_INTEGRATION_KEY')
+    const integratorSecret = requireEnv('SPRITZ_INTEGRATOR_SECRET')
+    const key = apiKey ?? optionalEnv('SPRITZ_API_KEY')
+
+    return new SpritzClient({
+        environment: 'staging',
         integrationKey,
         integratorSecret,
         apiKey: key,

--- a/scripts/sandbox/list-bank-accounts.ts
+++ b/scripts/sandbox/list-bank-accounts.ts
@@ -6,12 +6,13 @@
  *
  * Requires SPRITZ_API_KEY in .env
  */
-import { createClient } from './client'
+import { createClient, createRestClient } from './client'
 import { requireEnv } from './env'
 
 async function main() {
-    requireEnv('SPRITZ_API_KEY')
+    const apiKey = requireEnv('SPRITZ_API_KEY')
     const client = createClient()
+    const rest = createRestClient(apiKey)
 
     // GraphQL path
     console.log('=== Bank Accounts (GraphQL) ===')
@@ -23,7 +24,7 @@ async function main() {
 
     // REST API path (HMAC-signed)
     console.log('\n=== Bank Accounts (REST API) ===')
-    const restAccounts = await client.restApi({
+    const restAccounts = await rest.restApi({
         method: 'get',
         path: '/v1/bank-accounts/',
     })

--- a/scripts/sandbox/list-off-ramps.ts
+++ b/scripts/sandbox/list-off-ramps.ts
@@ -8,7 +8,7 @@
  *
  * Requires SPRITZ_API_KEY in .env
  */
-import { createClient } from './client'
+import { createRestClient } from './client'
 import { requireEnv } from './env'
 
 function parseArgs(args: string[]): Record<string, string> {
@@ -23,7 +23,7 @@ function parseArgs(args: string[]): Record<string, string> {
 }
 
 async function main() {
-    requireEnv('SPRITZ_API_KEY')
+    const apiKey = requireEnv('SPRITZ_API_KEY')
     const query = parseArgs(process.argv.slice(2))
 
     console.log('=== Off-Ramps (REST API) ===')
@@ -31,8 +31,8 @@ async function main() {
         console.log('Filters:', query)
     }
 
-    const client = createClient()
-    const offRamps = await client.restApi({
+    const rest = createRestClient(apiKey)
+    const offRamps = await rest.restApi({
         method: 'get',
         path: '/v1/off-ramps/',
         query,

--- a/scripts/sandbox/list-on-ramps.ts
+++ b/scripts/sandbox/list-on-ramps.ts
@@ -7,7 +7,7 @@
  *
  * Requires SPRITZ_API_KEY in .env
  */
-import { createClient } from './client'
+import { createRestClient } from './client'
 import { requireEnv } from './env'
 
 function parseArgs(args: string[]): Record<string, string> {
@@ -22,7 +22,7 @@ function parseArgs(args: string[]): Record<string, string> {
 }
 
 async function main() {
-    requireEnv('SPRITZ_API_KEY')
+    const apiKey = requireEnv('SPRITZ_API_KEY')
     const query = parseArgs(process.argv.slice(2))
 
     console.log('=== On-Ramps (REST API) ===')
@@ -30,8 +30,8 @@ async function main() {
         console.log('Filters:', query)
     }
 
-    const client = createClient()
-    const onRamps = await client.restApi({
+    const rest = createRestClient(apiKey)
+    const onRamps = await rest.restApi({
         method: 'get',
         path: '/v1/on-ramps/',
         query,

--- a/scripts/sandbox/setup-user.ts
+++ b/scripts/sandbox/setup-user.ts
@@ -6,7 +6,7 @@
  *
  * If no email is provided, generates one using a timestamp.
  */
-import { createClient } from './client'
+import { createClient, createRestClient } from './client'
 
 const email = process.argv[2] ?? `sandbox+${Date.now()}@spritz.finance`
 
@@ -20,8 +20,8 @@ async function main() {
 
     // Bypass KYC via REST API (HMAC-signed)
     console.log('\nBypassing KYC...')
-    client.setApiKey(user.apiKey)
-    await client.restApi({
+    const rest = createRestClient(user.apiKey)
+    await rest.restApi({
         method: 'post',
         path: '/v1/sandbox/bypass-kyc',
         body: { country: 'US' },
@@ -29,6 +29,7 @@ async function main() {
     console.log('KYC bypassed (US)')
 
     // Verify by fetching user profile
+    client.setApiKey(user.apiKey)
     const currentUser = await client.user.getCurrentUser()
     console.log('\nUser profile:')
     console.log(JSON.stringify(currentUser, null, 2))

--- a/src/spritzApiClient.ts
+++ b/src/spritzApiClient.ts
@@ -137,19 +137,6 @@ export class SpritzApiClient {
         this.webhook = new WebhookService(this.client)
     }
 
-    /**
-     * Make a direct REST API call to the platform.
-     * Requests are HMAC-signed when integratorSecret is configured.
-     */
-    public async restApi<Response, Request extends Record<string, unknown> = Record<string, unknown>>(args: {
-        method: 'get' | 'post' | 'put' | 'patch' | 'delete'
-        path: string
-        body?: Request
-        query?: Record<string, string | number | boolean | undefined>
-    }) {
-        return this.client.restApi<Response, Request>(args)
-    }
-
     setApiKey(_apiKey: string) {
         this.apiKey = _apiKey
         this.init()


### PR DESCRIPTION
- Add `createRestClient` to provide a low-level, HMAC-signed REST client separate from the high-level service client
- Update sandbox scripts to call `rest.restApi(...)` instead of `client.restApi(...)`, keeping GraphQL/service usage on the high-level client
- Pass API keys explicitly when creating REST clients and avoid mutating the high-level client for REST operations
- Remove `SpritzApiClient.restApi` passthrough to discourage direct REST calls from the high-level client and centralize REST usage in the dedicated client