### PR TITLE
Revert bankAccount.list() to GraphQL to preserve response contract

### DIFF
--- a/.changeset/revert-bank-account-list-rest.md
+++ b/.changeset/revert-bank-account-list-rest.md
@@ -1,0 +1,5 @@
+---
+'@spritz-finance/api-client': patch
+---
+
+Revert `client.bankAccount.list()` to the `UserBankAccounts` GraphQL query. The REST `/v1/bank-accounts/` payload omits `userId`, `institution.id`, `institution.country`, `email`, `ownedByUser`, and `paymentAddresses`, and the previous shim filled those slots with empty strings and hardcoded values, silently changing the contract for existing consumers. Restoring the GraphQL path keeps the returned shape identical to prior releases.

--- a/src/modules/bankAccount/bankAccountService.ts
+++ b/src/modules/bankAccount/bankAccountService.ts
@@ -16,99 +16,16 @@ import {
 import CreateBankAccountMutation from '../../graph/mutations/createBankAccount.graphql'
 import DeletePayableAccountMutation from '../../graph/mutations/deletePayableAccount.graphql'
 import RenameBankAccountMutation from '../../graph/mutations/renameBankAccount.graphql'
-import type {
-    UserBankAccounts_bankAccounts,
-    UserBankAccounts_bankAccounts_bankAccountDetails,
-    UserBankAccounts_bankAccounts_institution,
-} from '../../graph/queries/__types__/UserBankAccounts'
+import { UserBankAccounts } from '../../graph/queries/__types__'
+import UserBankAccountsQuery from '../../graph/queries/bankAccounts.graphql'
 import { SpritzClient } from '../../lib/client'
 import type { PathRequestBody, PathResponse } from '../../rest/types'
-import {
-    BankAccountInput,
-    BankAccountSubType,
-    BankAccountType,
-    PayableAccountType,
-    PaymentDeliveryMethod,
-} from '../../types/globalTypes'
+import { BankAccountInput, BankAccountType } from '../../types/globalTypes'
 import { raise } from '../../utils/raise'
 import { BankAccountDetailsValidation } from './validation'
 
 export type LinkTokenResponse = PathResponse<'/v1/bank-accounts/link-token', 'post'>
 export type CompleteLinkingRequest = PathRequestBody<'/v1/bank-accounts/link-complete', 'post'>
-
-type RestBankAccount = PathResponse<'/v1/bank-accounts/', 'get'>[number]
-
-const REST_TYPE_TO_BANK_ACCOUNT_TYPE: Record<string, BankAccountType> = {
-    us: BankAccountType.USBankAccount,
-    ca: BankAccountType.CABankAccount,
-    uk: BankAccountType.UKBankAccount,
-    iban: BankAccountType.IbanAccount,
-}
-
-const REST_SUBTYPE_TO_ENUM: Record<string, BankAccountSubType> = {
-    checking: BankAccountSubType.Checking,
-    savings: BankAccountSubType.Savings,
-}
-
-function transformBankAccount(acct: RestBankAccount): UserBankAccounts_bankAccounts {
-    const bankAccountType =
-        REST_TYPE_TO_BANK_ACCOUNT_TYPE[acct.type] ?? BankAccountType.USBankAccount
-
-    let bankAccountDetails: UserBankAccounts_bankAccounts_bankAccountDetails | null = null
-    if (acct.type === 'us' && 'routingNumberLast4' in acct) {
-        bankAccountDetails = {
-            __typename: 'USBankAccountDetails',
-            routingNumber: acct.routingNumberLast4,
-        }
-    }
-
-    let institution: UserBankAccounts_bankAccounts_institution | null = null
-    if (acct.institution) {
-        institution = {
-            __typename: 'BankAccountInstitution',
-            id: '',
-            name: acct.institution.name,
-            logo: acct.institution.logo ?? null,
-            country: '',
-            currency: acct.currency,
-        }
-    }
-
-    const subtype =
-        'accountSubtype' in acct && acct.accountSubtype
-            ? (REST_SUBTYPE_TO_ENUM[acct.accountSubtype] ?? BankAccountSubType.Checking)
-            : BankAccountSubType.Checking
-
-    return {
-        __typename: 'BankAccount',
-        id: acct.id,
-        name: acct.label ?? null,
-        userId: '',
-        country:
-            acct.currency === 'USD'
-                ? 'US'
-                : acct.currency === 'CAD'
-                  ? 'CA'
-                  : acct.currency === 'GBP'
-                    ? 'GB'
-                    : '',
-        currency: acct.currency,
-        createdAt: acct.createdAt,
-        type: PayableAccountType.BankAccount,
-        accountNumber: 'accountNumberLast4' in acct ? `****${acct.accountNumberLast4}` : '',
-        bankAccountType,
-        bankAccountSubType: subtype,
-        email: null,
-        ownedByUser: true,
-        bankAccountDetails,
-        deliveryMethods: [
-            PaymentDeliveryMethod.STANDARD,
-            ...(acct.supportedRails.includes('rtp') ? [PaymentDeliveryMethod.INSTANT] : []),
-        ],
-        institution,
-        paymentAddresses: [],
-    }
-}
 
 type BaseBankAccountInput = Omit<BankAccountInput, 'details' | 'type'>
 
@@ -142,11 +59,10 @@ export class BankAccountService {
     }
 
     public async list() {
-        const accounts = await this.client.restApi<PathResponse<'/v1/bank-accounts/', 'get'>>({
-            method: 'get',
-            path: '/v1/bank-accounts/',
+        const response = await this.client.query<UserBankAccounts>({
+            query: UserBankAccountsQuery,
         })
-        return accounts.map(transformBankAccount)
+        return response?.bankAccounts ?? []
     }
 
     public async rename(accountId: string, name: string) {


### PR DESCRIPTION
- Switch `client.bankAccount.list()` back from REST `/v1/bank-accounts/` to the `UserBankAccounts` GraphQL query
- Remove the REST-to-GraphQL shim that filled missing fields with empty strings/hardcoded values
- Preserve the previously returned response shape by returning `response.bankAccounts ?? []` from GraphQL