### PR TITLE
Expose ACH debit release surface + webhook updates; restore bankAccount.list

### DIFF
--- a/.changeset/ach-debit-partner-qc.md
+++ b/.changeset/ach-debit-partner-qc.md
@@ -1,0 +1,7 @@
+---
+'@spritz-finance/api-client': minor
+---
+
+Expose the full partner-facing ACH debit release surface: funding-source deposit limits, RFC 7807 error messages, sandbox ACH return simulation, webhook event updates, and SDK-backed QC evidence tooling.
+
+Add typed webhook subscription updates via `client.webhook.update(webhookId, { events })`, including support for ACH on-ramp events, ACH debit return events, and `'*'` for all webhook events.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/.DS_Store
 demo.ts
 coverage/
 .claude/
+qc/evidence/*.json

--- a/README.md
+++ b/README.md
@@ -951,9 +951,11 @@ import { createHmac, timingSafeEqual } from 'node:crypto'
 
 function verifySpritzWebhook(rawBody: string, signature: string, secret: string) {
     const expected = createHmac('sha256', secret).update(rawBody).digest('hex')
+    const expectedBuffer = Buffer.from(expected, 'utf8')
+    const signatureBuffer = Buffer.from(signature, 'utf8')
 
-    if (expected.length !== signature.length) return false
-    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature))
+    if (expectedBuffer.length !== signatureBuffer.length) return false
+    return timingSafeEqual(expectedBuffer, signatureBuffer)
 }
 
 const signature = request.headers['signature']

--- a/README.md
+++ b/README.md
@@ -817,13 +817,19 @@ const accounts = await client.virtualAccounts.list()
 
 ## ACH Onramp (Direct Debit)
 
-ACH onramp lets users convert USD from their bank account into USDC delivered to a Solana wallet. The flow is:
+ACH onramp lets users convert USD from their bank account into USDC delivered to a Solana wallet. The integration is a short server-side flow with one client-side Plaid step:
 
-1. **Link bank account** via Plaid → funding source created automatically
-2. **Prepare deposit** — quote and ACH authorization message for the user to review
-3. **Create deposit** — confirm to debit the bank and release USDC to the wallet
+1. **Server:** create a Plaid link token with `client.bankAccount.createLinkToken()`
+2. **Client:** run Plaid Link and send the public token/account IDs back to your server
+3. **Server:** complete linking with `client.bankAccount.completeLinking(...)`
+4. **Server:** find an active funding source and fetch limits with `client.fundingSource.getDepositLimits(id)`
+5. **Server:** prepare a quote with `client.deposit.prepare(...)`
+6. **Client:** show the quote and ACH authorization message to the user
+7. **Server:** create the deposit with `client.deposit.create(...)`; Spritz runs risk checks before initiating the ACH pull
 
 Authorization is derived from the verified ACH funding source — no wallet signature is required.
+
+If risk checks block the create step, the API returns 409 before any ACH debit is pulled. Prepare a new quote before retrying; blocked create attempts consume the original `preparationId`.
 
 For a complete walkthrough with code examples, request/response schemas, and deposit lifecycle documentation, see the **[ACH Onramp Integration Guide](docs/ach-onramp-guide.md)**.
 
@@ -906,7 +912,7 @@ await client.webhook.delete('webhook-id')
 
 ### Security and Signing
 
-Webhook requests are signed with HMAC SHA256 using your webhook secret. The signature is sent in the `Signature` HTTP header.
+Webhook requests are signed with HMAC SHA256 using your webhook secret. The signature is sent in the `Signature` HTTP header. Verify the signature against the raw request body before parsing JSON.
 
 #### Setting a Webhook Secret
 
@@ -917,11 +923,17 @@ await client.webhook.updateWebhookSecret('your-secret')
 #### Verifying Signatures
 
 ```typescript
-import { createHmac } from 'crypto'
+import { createHmac, timingSafeEqual } from 'node:crypto'
 
-const expected = createHmac('sha256', WEBHOOK_SECRET).update(JSON.stringify(payload)).digest('hex')
+function verifySpritzWebhook(rawBody: string, signature: string, secret: string) {
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex')
 
-if (expected !== request.headers['signature']) {
+    if (expected.length !== signature.length) return false
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature))
+}
+
+const signature = request.headers['signature']
+if (!signature || !verifySpritzWebhook(rawBody, signature, WEBHOOK_SECRET)) {
     throw new Error('Invalid webhook signature')
 }
 ```

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ If risk checks block the create step, the API returns 409 before any ACH debit i
 
 For a complete walkthrough with code examples, request/response schemas, and deposit lifecycle documentation, see the **[ACH Onramp Integration Guide](docs/ach-onramp-guide.md)**.
 
-A standalone sandbox demo is available at `scripts/sandbox/ach-onramp.html` — open it in a browser to walk through the full flow interactively.
+A standalone sandbox demo is available at `scripts/sandbox/ach-onramp.html`. Run `yarn build && node scripts/sandbox/evidence-server.mjs`, then open `http://localhost:3001/ach-onramp.html` to test the SDK-backed flow and save redacted QC evidence.
 
 ## Sandbox
 
@@ -881,12 +881,31 @@ This endpoint returns 403 in production.
 
 - `capabilities.updated` — user capabilities changed
 
+#### On-Ramp Events
+
+- `onramp.created` — on-ramp record created after a deposit is authorized
+- `onramp.updated` — on-ramp status, delivery, or reversal details updated
+- `onramp.completed` — on-ramp delivery completed
+
+#### ACH Debit Return Events
+
+- `achDebitReturn.created` — ACH debit return recorded
+- `achDebitReturn.updated` — ACH debit return details updated
+
+Use `'*'` to subscribe a webhook endpoint to all current and future webhook events.
+
 ### Setup
 
 ```typescript
 const webhook = await client.webhook.create({
     url: 'https://my.webhook.url/spritz',
-    events: ['account.created', 'account.updated', 'payment.completed'],
+    events: ['onramp.created', 'onramp.updated', 'achDebitReturn.created'],
+})
+
+// Subscribe to all events
+await client.webhook.create({
+    url: 'https://my.webhook.url/spritz/all',
+    events: ['*'],
 })
 ```
 
@@ -905,6 +924,11 @@ Webhook payloads have the following shape:
 ```typescript
 // List all webhooks
 const webhooks = await client.webhook.list()
+
+// Update a webhook's event subscriptions
+await client.webhook.update('webhook-id', {
+    events: ['onramp.updated', 'achDebitReturn.created', 'achDebitReturn.updated'],
+})
 
 // Delete a webhook
 await client.webhook.delete('webhook-id')

--- a/docs/ach-onramp-guide.md
+++ b/docs/ach-onramp-guide.md
@@ -494,14 +494,26 @@ await client.webhook.updateWebhookSecret(process.env.SPRITZ_WEBHOOK_SECRET!)
 
 const webhook = await client.webhook.create({
     url: 'https://api.example.com/spritz/webhooks',
-    events: ['payment.created', 'payment.updated', 'payment.completed'],
+    events: ['onramp.created', 'onramp.updated', 'achDebitReturn.created'],
 })
 ```
 
 Key events to handle:
 
-- **Deposit status change** — debit submitted, settled, returned, failed
-- **Release status change** — USDC queued, released, failed
+- `onramp.created` — on-ramp record created after the ACH deposit is authorized
+- `onramp.updated` — on-ramp status, delivery, or reversal details updated
+- `onramp.completed` — on-ramp delivery completed
+- `achDebitReturn.created` — ACH debit return recorded
+- `achDebitReturn.updated` — ACH debit return details updated
+
+To subscribe an endpoint to every current and future event, use `events: ['*']`.
+To change an existing webhook's event subscriptions:
+
+```typescript
+await client.webhook.update(webhook.id, {
+    events: ['onramp.updated', 'achDebitReturn.created', 'achDebitReturn.updated'],
+})
+```
 
 Webhook requests are signed with HMAC SHA256 using your webhook secret. Verify the signature against the **raw request body** before parsing JSON:
 
@@ -528,6 +540,24 @@ All endpoints return [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807) p
     "title": "Invalid Input",
     "status": 400,
     "detail": "amountUsd must be a positive decimal string"
+}
+```
+
+The SDK throws typed errors with the status, message, response IDs, and parsed problem payload:
+
+```typescript
+import { PermissionDeniedError } from '@spritz-finance/api-client'
+
+try {
+    await client.bankAccount.createLinkToken()
+} catch (error) {
+    if (error instanceof PermissionDeniedError) {
+        console.error(error.status) // 403
+        console.error(error.message) // human-readable detail
+        console.error(error.error?.requirement) // identity verification requirement, if returned
+        console.error(error.headers?.requestId)
+    }
+    throw error
 }
 ```
 
@@ -558,14 +588,14 @@ Use `Environment.Sandbox` for testing. The sandbox base URL is `https://sandbox.
     ./scripts/sandbox/run.sh setup-user
     ```
 
-2. Serve the interactive demo over HTTP and open it (the demo will not work from `file://` because Plaid Link requires an `http(s)` origin):
+2. Build the SDK bundle and start the interactive demo/evidence server:
 
     ```bash
-    npx serve scripts/sandbox
-    # then open http://localhost:3000/ach-onramp.html
+    yarn build
+    node scripts/sandbox/evidence-server.mjs
     ```
 
-    Enter your credentials and walk through the full flow.
+    Open `http://localhost:3001/ach-onramp.html`, enter your credentials, and walk through the full flow. The demo saves redacted QC evidence under `qc/evidence/`.
 
 ### Plaid sandbox credentials
 
@@ -580,7 +610,16 @@ Select any checking account to complete linking.
 
 Sandbox lets you create a deposit whose ACH debit is pre-armed to return with a specific NACHA code. The deposit moves through the normal lifecycle and lands in `returned` so you can exercise downstream handling end-to-end (webhooks, the integrator returns API, your reconciliation logic).
 
-Signal simulation happens before ACH initiation. Use the sandbox `signal` selector to force risk outcomes such as accepted, review, or reroute/rejected paths. When `signal` blocks the deposit, no ACH debit is pulled and no return simulation can run.
+Plaid Signal runs during deposit creation. In sandbox, Plaid supports amount-based Signal fixtures. Use the normal generated SDK fields and set the prepared deposit amount to exercise Signal behavior; do not send a `signal` request field.
+
+Useful Signal amount fixtures:
+
+| Amount  | Plaid Signal score | Expected Spritz behavior                           |
+| ------- | ------------------ | -------------------------------------------------- |
+| `12.17` | `60`               | Medium score, expected allow under local threshold |
+| `27.53` | `90`               | High score, expected pre-debit risk block          |
+
+`3.53` maps to score `10`, but it is below the current ACH minimum in this sandbox.
 
 ```typescript
 // 1. Prepare as normal
@@ -590,14 +629,13 @@ const preparation = await client.deposit.prepare({
     network: 'solana',
     asset: 'USDC',
     quoteType: 'exact_input',
-    amountUsd: '10.00',
+    amountUsd: '12.17',
     priority: 'normal',
 })
 
 // 2. Use the sandbox creator instead of client.deposit.create
 const deposit = await client.sandbox.createDepositWithReturn({
     preparationId: preparation.preparationId,
-    signal: { outcome: 'accept' },
     returnSimulation: { code: 'R01' }, // NACHA return code to arm
 })
 

--- a/docs/ach-onramp-guide.md
+++ b/docs/ach-onramp-guide.md
@@ -522,9 +522,11 @@ import { createHmac, timingSafeEqual } from 'node:crypto'
 
 function verifySpritzWebhook(rawBody: string, signature: string, secret: string) {
     const expected = createHmac('sha256', secret).update(rawBody).digest('hex')
+    const expectedBuffer = Buffer.from(expected, 'utf8')
+    const signatureBuffer = Buffer.from(signature, 'utf8')
 
-    if (expected.length !== signature.length) return false
-    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature))
+    if (expectedBuffer.length !== signatureBuffer.length) return false
+    return timingSafeEqual(expectedBuffer, signatureBuffer)
 }
 ```
 
@@ -596,6 +598,7 @@ Use `Environment.Sandbox` for testing. The sandbox base URL is `https://sandbox.
     ```
 
     Open `http://localhost:3001/ach-onramp.html`, enter your credentials, and walk through the full flow. The demo saves redacted QC evidence under `qc/evidence/`.
+    The evidence server binds to `127.0.0.1` by default. If you intentionally need a non-local browser to access it, run with `EVIDENCE_HOST=0.0.0.0`.
 
 ### Plaid sandbox credentials
 

--- a/docs/ach-onramp-guide.md
+++ b/docs/ach-onramp-guide.md
@@ -1,16 +1,55 @@
 # ACH Onramp Integration Guide
 
-ACH onramp lets your users convert USD from their bank account into USDC delivered to a Solana wallet. The user links a bank account via Plaid, then authorizes ACH debits that settle as USDC at a wallet address you supply. Authorization is derived from the verified ACH funding source — no wallet signature is required.
+ACH onramp lets your users convert USD from their bank account into USDC delivered to a Solana wallet. The integration is intentionally small: link a bank account with Plaid, choose an active funding source, check its limits, prepare a quote, show the ACH authorization text, then create the deposit.
+
+Authorization is derived from the verified ACH funding source — no wallet signature is required.
 
 ```
-Link Bank Account → Funding Source → Prepare Deposit → Create Deposit → USDC Released
-      (Plaid)        (automatic)        (quote)         (authorize)       (async)
+Plaid Link → Funding Source → Limits → Prepare Quote → User Confirms → Create Deposit → ACH Pull
+ (client)      (server)       (server)      (server)        (client)          (server)       (async)
 ```
 
 > **The SDK is server-side only.** It throws if instantiated in a browser without `dangerouslyAllowBrowser: true`. The integrator key and HMAC secret must never reach the client. The split is:
 >
 > - **Server** — every SDK call in this guide (link token, funding sources, prepare/create deposit, returns)
 > - **Client** — Plaid Link UI only
+
+## Minimal Server Flow
+
+Once your frontend has completed Plaid Link, the ACH flow is:
+
+```typescript
+await client.bankAccount.completeLinking({
+    publicToken,
+    accountIds,
+    institutionId,
+    institutionName,
+})
+
+const sources = await client.fundingSource.list()
+const source = sources.find((s) => s.status === 'active')
+if (!source) throw new Error('No active funding source available')
+
+const limits = await client.fundingSource.getDepositLimits(source.id)
+
+const preparation = await client.deposit.prepare({
+    sourceId: source.id,
+    address: walletAddress,
+    network: 'solana',
+    asset: 'USDC',
+    quoteType: 'exact_input',
+    amountUsd: '100.00',
+    priority: 'normal',
+})
+
+// Show preparation.summary and preparation.message to the user first.
+// The ACH pull is not started until create passes risk checks.
+const deposit = await client.deposit.create({
+    preparationId: preparation.preparationId,
+})
+```
+
+Use `limits` to keep your UI inside the user's current ACH capacity before preparing a quote. Use webhooks to track the deposit after creation; `onrampPayment` and `achDebitReturn` are the read APIs for reconciliation.
 
 ## Prerequisites
 
@@ -107,7 +146,7 @@ await client.bankAccount.completeLinking({
 const handler = Plaid.create({
     token: linkToken,
     onSuccess: async (publicToken, metadata) => {
-        await client.bankAccount.completeLinking({
+        await yourServer.completePlaidLink({
             publicToken,
             accountIds: metadata.accounts.map((a) => a.id),
             // Note: Web SDK uses institution_id, RN SDK uses id
@@ -123,7 +162,7 @@ The `completeLinking` call exchanges the Plaid public token and stores the linke
 
 ---
 
-## Step 2: Get Funding Source
+## Step 2: Get Funding Source And Limits
 
 A funding source represents a linked bank account that has been evaluated for ACH eligibility. After Plaid linking, query for available sources:
 
@@ -168,11 +207,36 @@ To fetch a specific source:
 const source = await client.fundingSource.get('fs_01JV7...')
 ```
 
+Before showing deposit amounts to the user, fetch the source's current ACH debit limits:
+
+```typescript
+const limits = await client.fundingSource.getDepositLimits(source.id)
+
+if (Number(limits.dailyRemainingUsd) <= 0) {
+    throw new Error('No remaining ACH deposit capacity today')
+}
+```
+
+**Deposit limit fields:**
+
+| Field                       | Type     | Description                                            |
+| --------------------------- | -------- | ------------------------------------------------------ |
+| `minimumDepositAmountUsd`   | `string` | Minimum deposit principal amount before fees           |
+| `transactionLimitUsd`       | `string` | Maximum ACH debit amount per deposit                   |
+| `dailyLimitUsd`             | `string` | Maximum daily ACH debit volume                         |
+| `dailyRemainingUsd`         | `string` | Remaining daily ACH debit volume                       |
+| `monthlyLimitUsd`           | `string` | Maximum monthly ACH debit volume                       |
+| `monthlyRemainingUsd`       | `string` | Remaining monthly ACH debit volume                     |
+| `unsettledDepositLimit`     | `number` | Maximum number of unsettled ACH debit deposits allowed |
+| `unsettledDepositRemaining` | `number` | Remaining unsettled deposit capacity                   |
+
+Limits are a pre-check for user experience. The API still validates limits and funding-source state again when you prepare and create the deposit.
+
 ---
 
 ## Step 3: Prepare Deposit
 
-A deposit initiates an ACH debit from the user's bank account and releases USDC to a Solana wallet you specify. Preparation returns a quote and a display-ready ACH authorization message.
+Preparation creates a quote and a display-ready ACH authorization message. It does not start the ACH pull. The pull is only initiated after the user confirms and `client.deposit.create(...)` passes risk checks.
 
 ```typescript
 const preparation = await client.deposit.prepare({
@@ -233,7 +297,7 @@ feeSubsidy: {
 | `summary.feeRateBps`          | `number` | Fee rate in basis points                      |
 | `summary.destinationAddress`  | `string` | Wallet receiving USDC                         |
 
-Display the summary and `message` to the user for review before proceeding.
+Display `summary` and `message` to the user for review before proceeding. The user-facing confirm button should call your server, and your server should then call `client.deposit.create(...)`.
 
 > **Compliance — display the authorization message verbatim.** `preparation.message` is the NACHA consent text that authorizes the ACH debit. It must be shown to the user as-is, unmodified, before they confirm. Paraphrasing, truncating, or styling away parts of the message is a NACHA compliance violation and will invalidate the authorization. Wrap it in a `<pre>` or equivalent so whitespace and line breaks are preserved.
 
@@ -242,6 +306,10 @@ Display the summary and `message` to the user for review before proceeding.
 ## Step 4: Create Deposit
 
 Once the user has reviewed the quote and authorization, submit the preparation ID to create the deposit. No signature is required — authorization is derived from the verified ACH funding source.
+
+When you call `create`, Spritz runs Plaid Signal/risk checks after the user has confirmed but before the ACH pull is initiated. If the risk result blocks the transaction, the API returns 409 and no ACH debit is pulled.
+
+Blocked create attempts consume the `preparationId`. After a blocked or expired attempt, prepare a new quote instead of retrying the same preparation.
 
 ```typescript
 const deposit = await client.deposit.create({
@@ -274,7 +342,7 @@ const deposit = await client.deposit.create({
 
 ## Step 5: Track Deposit Status
 
-Once a deposit is authorized, an **on-ramp record** is created and is the canonical place to observe its state going forward — listing or fetching the deposit by ID directly is not exposed. The on-ramp model unifies all fiat→crypto transactions (ACH, wire, SEPA), so the same APIs work for any rail.
+Once a deposit is authorized, an **on-ramp record** is created and is the canonical place to observe its state going forward. Listing or fetching the deposit by ID directly is not exposed. The on-ramp model unifies all fiat→crypto transactions (ACH, wire, SEPA), so the same APIs work for any rail.
 
 ```typescript
 // List the user's recent on-ramps (newest first by default)
@@ -419,12 +487,34 @@ const ret = await client.achDebitReturn.get('dr_01JV7...')
 
 ## Webhooks
 
-Register a webhook to receive real-time notifications for deposit status changes. See the [webhook documentation](https://docs.spritz.finance/webhooks) for setup details.
+Register a webhook before launching ACH debit so your backend is notified when deposit state changes. Polling `onrampPayment` and `achDebitReturn` is useful for reconciliation, but webhooks should drive production updates.
+
+```typescript
+await client.webhook.updateWebhookSecret(process.env.SPRITZ_WEBHOOK_SECRET!)
+
+const webhook = await client.webhook.create({
+    url: 'https://api.example.com/spritz/webhooks',
+    events: ['payment.created', 'payment.updated', 'payment.completed'],
+})
+```
 
 Key events to handle:
 
 - **Deposit status change** — debit submitted, settled, returned, failed
 - **Release status change** — USDC queued, released, failed
+
+Webhook requests are signed with HMAC SHA256 using your webhook secret. Verify the signature against the **raw request body** before parsing JSON:
+
+```typescript
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+function verifySpritzWebhook(rawBody: string, signature: string, secret: string) {
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex')
+
+    if (expected.length !== signature.length) return false
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature))
+}
+```
 
 ---
 
@@ -450,6 +540,9 @@ Common error scenarios:
 | Funding source not found     | 404     | Resource not found                   |
 | Preparation expired          | 400/409 | Expired preparation ID               |
 | Funding source not active    | 400/409 | Source not eligible                  |
+| Risk review required         | 409     | `risk_review_required`               |
+| Risk rejected                | 409     | `risk_rejected`                      |
+| Risk evaluation unavailable  | 409     | `risk_evaluation_unavailable`        |
 
 ---
 
@@ -487,6 +580,8 @@ Select any checking account to complete linking.
 
 Sandbox lets you create a deposit whose ACH debit is pre-armed to return with a specific NACHA code. The deposit moves through the normal lifecycle and lands in `returned` so you can exercise downstream handling end-to-end (webhooks, the integrator returns API, your reconciliation logic).
 
+Signal simulation happens before ACH initiation. Use the sandbox `signal` selector to force risk outcomes such as accepted, review, or reroute/rejected paths. When `signal` blocks the deposit, no ACH debit is pulled and no return simulation can run.
+
 ```typescript
 // 1. Prepare as normal
 const preparation = await client.deposit.prepare({
@@ -502,6 +597,7 @@ const preparation = await client.deposit.prepare({
 // 2. Use the sandbox creator instead of client.deposit.create
 const deposit = await client.sandbox.createDepositWithReturn({
     preparationId: preparation.preparationId,
+    signal: { outcome: 'accept' },
     returnSimulation: { code: 'R01' }, // NACHA return code to arm
 })
 
@@ -534,6 +630,7 @@ This endpoint returns 403 in production. The 200 response shape is the same as `
 | `POST` | `/v1/bank-accounts/link-complete`             | `client.bankAccount.completeLinking(...)`     | Complete Plaid linking                                   |
 | `GET`  | `/v1/funding-sources/`                        | `client.fundingSource.list()`                 | List funding sources                                     |
 | `GET`  | `/v1/funding-sources/{id}`                    | `client.fundingSource.get(id)`                | Get funding source                                       |
+| `GET`  | `/v1/funding-sources/{id}/deposit-limits`     | `client.fundingSource.getDepositLimits(id)`   | Get current ACH debit limits                             |
 | `POST` | `/v1/deposits/direct/prepare`                 | `client.deposit.prepare(...)`                 | Prepare deposit quote                                    |
 | `POST` | `/v1/deposits/direct`                         | `client.deposit.create(...)`                  | Create deposit                                           |
 | `GET`  | `/v1/on-ramps/`                               | `client.onrampPayment.list(...)`              | List on-ramps (canonical deposit lookup)                 |

--- a/qc/ach-debit-example-app-e2e.md
+++ b/qc/ach-debit-example-app-e2e.md
@@ -28,7 +28,9 @@ Browser JavaScript cannot safely write directly to an arbitrary local path, so t
     node scripts/sandbox/evidence-server.mjs
     ```
 
-4. Open the forwarded URL for port `3001`, ending in `/ach-onramp.html`.
+    The server binds to `127.0.0.1` by default. Prefer an SSH port-forward for VPS/browser testing. If you intentionally need direct non-local access, run with `EVIDENCE_HOST=0.0.0.0`.
+
+4. Open `http://localhost:3001/ach-onramp.html`, or the forwarded URL for port `3001` ending in `/ach-onramp.html`.
 
 5. Fill in:
     - Integration key

--- a/qc/ach-debit-example-app-e2e.md
+++ b/qc/ach-debit-example-app-e2e.md
@@ -1,0 +1,203 @@
+# ACH Debit Example App E2E QC
+
+This runbook is for the ACH onramp example at `scripts/sandbox/ach-onramp.html`.
+
+The partner-facing ACH calls run through the built SDK on the local evidence server. The browser only drives the UI and Plaid Link; it does not hold HMAC signing code.
+
+The app captures every SDK request, SDK response, SDK error shape, Plaid Link outcome, selected funding source, deposit limit response, authorization message, deposit create response, on-ramp polling response, and ACH return polling response into a redacted evidence JSON file under `qc/evidence/`.
+
+Browser JavaScript cannot safely write directly to an arbitrary local path, so the repo includes a local evidence server. It serves the app and receives redacted evidence on the same origin, which works with VPS/port-forwarded browsers.
+
+## Setup
+
+1. Create or reuse a sandbox user with KYC bypassed:
+
+    ```bash
+    ./scripts/sandbox/run.sh setup-user
+    ```
+
+2. Build the SDK bundle used by the evidence server:
+
+    ```bash
+    yarn build
+    ```
+
+3. Start the app and evidence server:
+
+    ```bash
+    node scripts/sandbox/evidence-server.mjs
+    ```
+
+4. Open the forwarded URL for port `3001`, ending in `/ach-onramp.html`.
+
+5. Fill in:
+    - Integration key
+    - Integrator secret
+    - API key, or use **Generate Fresh User** to create one
+    - Solana destination wallet
+    - Deposit amount
+    - Optional fee subsidy
+    - Plaid Signal sandbox amount profile
+    - Optional sandbox ACH return code
+
+6. If Plaid Link opens, use Plaid sandbox credentials:
+    - Username: `user_good`
+    - Password: `pass_good`
+
+## Evidence Rules
+
+Run one scenario per browser run. Click **Clear Evidence** before each scenario. The app auto-saves evidence after completed flows and return polling; use **Save Evidence to Workspace** after blocked/error scenarios.
+
+Expected file names look like:
+
+```text
+ach-qc-2026-05-06T10-15-30-123Z.json
+```
+
+Files are written to `qc/evidence/` and intentionally ignored by git.
+
+Each file must be checked for:
+
+- No raw integrator secret, API key, Plaid public token, Plaid link token, Authorization header, or HMAC signature.
+- SDK `client.fundingSource.list()` response.
+- SDK `client.fundingSource.getDepositLimits(id)` response for `/v1/funding-sources/{id}/deposit-limits`.
+- Pre-KYC SDK `client.bankAccount.createLinkToken()` 403 evidence, including `PermissionDeniedError`, `status`, `message`, and problem-detail payload.
+- Pre-KYC raw REST parity evidence for `POST /v1/bank-accounts/link-token`.
+- Post-KYC SDK `client.bankAccount.createLinkToken()` success evidence.
+- Post-KYC raw REST parity evidence for `POST /v1/bank-accounts/link-token`.
+- SDK `client.deposit.prepare(...)` request and response.
+- The exact authorization message shown before confirm.
+- Confirm event after authorization review.
+- SDK create method:
+    - `client.deposit.create(...)` for normal create.
+    - `client.sandbox.createDepositWithReturn(...)` when ACH return simulation is selected.
+- Signal amount profile used for the run, because Plaid sandbox Signal is amount-driven.
+- Problem detail body on errors, including HTTP status and API code/type where returned.
+- Request IDs or trace IDs if the API returns them.
+
+## Scenarios
+
+### 0. Generated User And KYC Gate
+
+Inputs:
+
+- Integration key
+- Integrator secret
+- Optional sandbox user email
+
+Action:
+
+- Click **Generate Fresh User** to create a new unverified user and fill the API key.
+- Click **Bypass KYC (US)** if you only need to make the current API key usable.
+- Click **Full SDK KYC Gate QC** when you specifically want evidence that pre-KYC is blocked and post-KYC is allowed through the SDK.
+
+Expected:
+
+- Fresh user actions always create a unique sandbox user and fill the API key field.
+- `client.bankAccount.createLinkToken()` throws `PermissionDeniedError` with status `403` before verification.
+- The app bypasses KYC to `US` through `client.sandbox.bypassKyc(...)`.
+- `client.bankAccount.createLinkToken()` succeeds after verification.
+- Evidence is saved to `qc/evidence/`.
+
+### 1. Happy Path
+
+Inputs:
+
+- Signal amount profile: score `60` (`$12.17`)
+- Return code: blank
+
+Expected:
+
+- Funding source is `active`.
+- Deposit limits are returned.
+- Prepare succeeds and shows the authorization message.
+- User confirm creates a deposit.
+- Create uses `client.deposit.create(...)`; Signal behavior is driven by the prepared amount.
+- On-ramp polling uses:
+    - `client.onrampPayment.list(...)`
+    - `client.onrampPayment.get(onRampId)` when `bridgeOnRampId` is returned.
+
+### 2. Live Signal Unavailable Guard
+
+Inputs:
+
+- Signal amount profile: custom amount that does not map to a stable Plaid sandbox score
+- Return code: blank
+
+Expected:
+
+- Create uses `client.deposit.create(...)`.
+- If Plaid Signal is unavailable, SDK throws a clean 409 with `risk_evaluation_unavailable`.
+- No ACH debit is initiated.
+- The app says the preparation is consumed and prompts for a fresh quote.
+
+### 3. Signal Score 60 With Return Simulation
+
+Inputs:
+
+- Signal amount profile: score `60` (`$12.17`)
+- Return code: `R01`
+
+Expected:
+
+- Create uses `client.sandbox.createDepositWithReturn(...)`.
+- SDK request body includes `returnSimulation: { code: "R01" }`.
+- Deposit is created.
+- ACH returns polling eventually finds a return for the deposit.
+- Webhook receiver records the corresponding deposit/on-ramp lifecycle and return-related events.
+
+### 4. Signal High-Score Block
+
+Inputs:
+
+- Signal amount profile: score `90` (`$27.53`)
+- Return code: blank
+
+Expected:
+
+- Create uses `client.deposit.create(...)`.
+- SDK throws a clean 409 conflict with `risk_rejected` or equivalent public problem detail.
+- No ACH debit is initiated.
+- No ACH return can exist because Signal blocks before the pull.
+
+### 5. Signal Ruleset Review/Reroute
+
+Run only when the Plaid sandbox ruleset for this integrator maps an amount fixture to `REVIEW` or `REROUTE`.
+
+Inputs:
+
+- Signal amount profile configured to hit the sandbox ruleset action
+- Return code: blank
+
+Expected:
+
+- SDK throws a clean 409 conflict with `risk_review_required` or `risk_rejected`.
+- No deposit/on-ramp is created.
+- No ACH debit is initiated.
+
+### 6. Unauthorized Return
+
+Run once with `R10` and once with `R29`.
+
+Inputs:
+
+- Signal amount profile: score `60` (`$12.17`)
+- Return code: `R10` or `R29`
+
+Expected:
+
+- Deposit is created through `/v1/sandbox/deposits/direct`.
+- ACH return polling eventually finds the return.
+- Return record has the expected `returnCode`.
+- User/source action fields reflect unauthorized-return handling.
+- Webhook receiver captures return-related event delivery and signature verification passes.
+
+## Review Checklist
+
+- Partner flow is simple: link bank, fetch source, fetch limits, prepare, confirm, create.
+- Errors are actionable and do not expose internals.
+- Risk blocks happen after confirm and before ACH initiation.
+- Return simulations happen only after an accepted create.
+- Polling works through `onrampPayment` and `achDebitReturn`.
+- Webhooks are verified end-to-end with raw-body signature validation.
+- Evidence files are sufficient for a third party to audit the run without local browser state.

--- a/qc/ach-debit-release-qc.md
+++ b/qc/ach-debit-release-qc.md
@@ -55,6 +55,10 @@ Open scope questions:
 
 - What exact product behavior should medium-risk Signal produce: allow, review, delayed release, or block?
 
+Known API gaps to resolve before sign-off:
+
+- The generated webhook event enum currently does not expose explicit ACH deposit, on-ramp, or ACH return event names. Confirm whether existing generic events are the intended subscription mechanism, or update the backend/OpenAPI contract before E2E webhook certification.
+
 ## QC Matrix
 
 | Area             | Scenario                                    | Expected SDK/API Behavior                                                                                  | Required Evidence                    |

--- a/qc/ach-debit-release-qc.md
+++ b/qc/ach-debit-release-qc.md
@@ -53,81 +53,109 @@ Partner-facing SDK surface:
 
 Open scope questions:
 
-- What exact product behavior should medium-risk Signal produce: allow, review, delayed release, or block?
+- What exact Signal fixture should represent partner-facing "medium risk": a Plaid ruleset `review` outcome, or an accepted score below Spritz's local block threshold?
+
+Confirmed product behavior:
+
+- Plaid Signal runs during `client.deposit.create(...)`, after the user confirms the ACH authorization and before Spritz initiates the ACH pull.
+- A blocked/rerouted Signal result must return a clean 409 error and must not create or submit an ACH debit.
+- Signal `review` maps to `risk_review_required`; `reject`, `reroute`, and local-threshold blocks map to `risk_rejected`; unavailable/insufficient data maps to `risk_evaluation_unavailable`.
+- A blocked create attempt consumes the preparation. The partner must prepare a new quote after resolving the issue, not retry the same `preparationId`.
 
 Known API gaps to resolve before sign-off:
 
-- The generated webhook event enum currently does not expose explicit ACH deposit, on-ramp, or ACH return event names. Confirm whether existing generic events are the intended subscription mechanism, or update the backend/OpenAPI contract before E2E webhook certification.
+- Signal simulation is partner-release scope and should use the sandbox `signal` selector. The SDK/OpenAPI contract in this worktree must be refreshed or extended so `client.sandbox.createDepositWithReturn(...)` accepts it with strong types.
+- The generated webhook event enum currently exposes legacy account/payment/capability events only. Platform emits internal ACH events such as `deposit.created`, `deposit.updated`, `deposit-return.created`, and `deposit-return.updated`, but this repo does not show a public webhook subscription/delivery contract for those ACH events. Confirm whether legacy `payment.*` events are the intended public mapping, or update the backend/OpenAPI contract before E2E webhook certification.
+
+## Backend Contract Check
+
+Verified against `~/dev/spritz/platform` on 2026-05-06.
+
+Create order:
+
+1. `client.deposit.create(...)` calls the direct create path.
+2. Backend claims and marks the preparation used.
+3. Backend evaluates Plaid Signal with `clientTransactionId = depositId`.
+4. Backend persists the risk evaluation.
+5. If Signal outcome is not `created`, backend returns 409 and no deposit row is inserted.
+6. If Signal outcome is `created`, backend inserts the deposit with `debitStatus = authorized`.
+7. Backend publishes `deposit.created`; async workers handle ACH submission and on-ramp sync.
+
+Sandbox reality:
+
+- `/v1/sandbox/deposits` and `/v1/sandbox/deposits/direct` support `returnSimulation.code`.
+- Signal simulation should be exposed as `signal` on the sandbox create payload.
+- The current generated SDK types only show `returnSimulation`, so SDK contract work is still required before sign-off.
 
 ## QC Matrix
 
-| Area             | Scenario                                    | Expected SDK/API Behavior                                                                                  | Required Evidence                    |
-| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| Client setup     | Missing `apiKey` and `integrationKey`       | Constructor throws clear credential error                                                                  | Unit test                            |
-| Client setup     | `integratorSecret` without `integrationKey` | Constructor throws clear HMAC config error                                                                 | Unit test                            |
-| Client setup     | Browser without `dangerouslyAllowBrowser`   | Constructor blocks secret exposure                                                                         | Unit test                            |
-| Bank linking     | Create Plaid link token                     | Calls `POST /v1/bank-accounts/link-token`; returns `linkToken`, `hostedLinkUrl`, `expiration`              | Contract test                        |
-| Bank linking     | Complete Plaid Link                         | Calls `POST /v1/bank-accounts/link-complete`; sends `publicToken`, `accountIds`, institution metadata      | Contract test + sandbox run          |
-| Funding source   | List empty sources                          | Returns empty array; docs tell partner to link bank                                                        | Contract test                        |
-| Funding source   | Pending source                              | SDK surfaces `pending`; partner should retry/poll                                                          | Contract test + docs                 |
-| Funding source   | Active source                               | SDK surfaces source usable for prepare                                                                     | Contract test + sandbox run          |
-| Funding source   | Ineligible/review/disabled source           | Prepare/create does not proceed; error is clear                                                            | Contract test + sandbox/error test   |
-| Funding source   | Get by ID with unsafe chars                 | ID is URL encoded                                                                                          | Contract test                        |
-| Funding source   | Get deposit limits                          | Calls `GET /v1/funding-sources/{id}/deposit-limits`; exposes transaction, daily, monthly, unsettled limits | Contract test + sandbox run          |
-| Deposit prepare  | Exact input quote                           | Sends expected body; returns `preparationId`, `message`, `summary`                                         | Contract test                        |
-| Deposit prepare  | Exact output quote                          | Sends expected body; amount semantics documented                                                           | Contract test                        |
-| Deposit prepare  | Fee subsidy                                 | Sends `feeSubsidy`; response exposes gross/user/subsidy fields                                             | Contract test                        |
-| Deposit prepare  | Client context                              | Sends `clientContext` unchanged                                                                            | Contract test                        |
-| Deposit prepare  | Invalid wallet                              | Throws clean validation/problem error                                                                      | Error test + sandbox/API check       |
-| Deposit prepare  | Inactive funding source                     | Throws clean state/eligibility error                                                                       | Error test                           |
-| Authorization    | ACH authorization message                   | Partner must display `message` verbatim before create                                                      | Docs review + sandbox screenshot     |
-| Deposit create   | Happy path                                  | Calls `POST /v1/deposits/direct`; returns deposit lifecycle fields                                         | Contract test + sandbox run          |
-| Deposit create   | Expired preparation                         | Throws clean expired preparation error                                                                     | Error test                           |
-| Deposit create   | Reused preparation                          | Throws clean conflict/idempotency error                                                                    | Error test                           |
-| Deposit create   | High-risk Signal                            | No ACH debit is initiated; SDK error is actionable                                                         | Signal simulation + sandbox evidence |
-| On-ramp tracking | List on-ramps                               | Query params serialize correctly; pagination fields exposed                                                | Contract test + sandbox run          |
-| On-ramp tracking | Get on-ramp                                 | ID is URL encoded; lifecycle fields documented                                                             | Contract test                        |
-| Returns          | Simulate `R01`                              | Deposit reaches returned path; return record exists                                                        | Sandbox run                          |
-| Returns          | Simulate `R10`                              | Unauthorized bucket/user action path covered                                                               | Sandbox run                          |
-| Returns          | Simulate `R29`                              | Corporate unauthorized path covered                                                                        | Sandbox run                          |
-| Returns          | List filters                                | `returnCode`, `returnBucket`, `lossOnly`, `userAction`, date bounds, pagination serialize correctly        | Contract test + sandbox run          |
-| Returns          | Get return by ID                            | ID is URL encoded; return fields exposed                                                                   | Contract test                        |
-| Webhooks         | Create webhook                              | Webhook can be registered for ACH-relevant events against a real HTTPS receiver                            | Contract test + sandbox run          |
-| Webhooks         | Configure secret                            | Webhook secret is configured before event testing                                                          | Contract test + sandbox run          |
-| Webhooks         | Verify signature                            | Receiver validates HMAC signature using raw request body                                                   | Local receiver test + sandbox run    |
-| Webhooks         | Receive deposit event                       | Deposit lifecycle event is delivered after sandbox deposit creation                                        | Sandbox run                          |
-| Webhooks         | Receive return event                        | Return-related event is delivered after sandbox return simulation                                          | Sandbox run                          |
-| Webhooks         | List/delete webhook                         | Webhook appears in list and can be deleted during cleanup                                                  | Contract test + sandbox run          |
-| Auth             | Bad bearer token                            | Throws `AuthenticationError` with clear message and IDs                                                    | Error test                           |
-| Auth             | Missing/invalid HMAC                        | Throws clean auth/permission error                                                                         | Error test                           |
-| Auth             | Feature disabled                            | Throws `PermissionDeniedError` with clear message                                                          | Error test                           |
-| Reliability      | Timeout                                     | Throws `APIConnectionTimeoutError`                                                                         | Unit test                            |
-| Reliability      | Network failure                             | Throws `APIConnectionError` with cause                                                                     | Unit test                            |
-| Reliability      | 429                                         | Throws `RateLimitError` with clean retry context if provided                                               | Error test                           |
-| Reliability      | 500                                         | Throws `InternalServerError`; request/trace IDs preserved                                                  | Error test                           |
+| Area             | Scenario                                    | Expected SDK/API Behavior                                                                                  | Required Evidence                                                  |
+| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Client setup     | Missing `apiKey` and `integrationKey`       | Constructor throws clear credential error                                                                  | Unit test                                                          |
+| Client setup     | `integratorSecret` without `integrationKey` | Constructor throws clear HMAC config error                                                                 | Unit test                                                          |
+| Client setup     | Browser without `dangerouslyAllowBrowser`   | Constructor blocks secret exposure                                                                         | Unit test                                                          |
+| Bank linking     | Create Plaid link token                     | Calls `POST /v1/bank-accounts/link-token`; returns `linkToken`, `hostedLinkUrl`, `expiration`              | Contract test                                                      |
+| Bank linking     | Complete Plaid Link                         | Calls `POST /v1/bank-accounts/link-complete`; sends `publicToken`, `accountIds`, institution metadata      | Contract test + sandbox run                                        |
+| Funding source   | List empty sources                          | Returns empty array; docs tell partner to link bank                                                        | Contract test                                                      |
+| Funding source   | Pending source                              | SDK surfaces `pending`; partner should retry/poll                                                          | Contract test + docs                                               |
+| Funding source   | Active source                               | SDK surfaces source usable for prepare                                                                     | Contract test + sandbox run                                        |
+| Funding source   | Ineligible/review/disabled source           | Prepare/create does not proceed; error is clear                                                            | Contract test + sandbox/error test                                 |
+| Funding source   | Get by ID with unsafe chars                 | ID is URL encoded                                                                                          | Contract test                                                      |
+| Funding source   | Get deposit limits                          | Calls `GET /v1/funding-sources/{id}/deposit-limits`; exposes transaction, daily, monthly, unsettled limits | Contract test + sandbox run                                        |
+| Deposit prepare  | Exact input quote                           | Sends expected body; returns `preparationId`, `message`, `summary`                                         | Contract test                                                      |
+| Deposit prepare  | Exact output quote                          | Sends expected body; amount semantics documented                                                           | Contract test                                                      |
+| Deposit prepare  | Fee subsidy                                 | Sends `feeSubsidy`; response exposes gross/user/subsidy fields                                             | Contract test                                                      |
+| Deposit prepare  | Client context                              | Sends `clientContext` unchanged                                                                            | Contract test                                                      |
+| Deposit prepare  | Invalid wallet                              | Throws clean validation/problem error                                                                      | Error test + sandbox/API check                                     |
+| Deposit prepare  | Inactive funding source                     | Throws clean state/eligibility error                                                                       | Error test                                                         |
+| Authorization    | ACH authorization message                   | Partner must display `message` verbatim before create                                                      | Docs review + sandbox screenshot                                   |
+| Deposit create   | Happy path                                  | Calls `POST /v1/deposits/direct`; returns deposit lifecycle fields                                         | Contract test + sandbox run                                        |
+| Deposit create   | Expired preparation                         | Throws clean expired preparation error                                                                     | Error test                                                         |
+| Deposit create   | Reused preparation                          | Throws clean conflict/idempotency error                                                                    | Error test                                                         |
+| Deposit create   | High-risk Signal                            | No ACH debit is initiated; SDK error is actionable                                                         | Signal simulation or documented backend fixture + sandbox evidence |
+| On-ramp tracking | List on-ramps                               | Query params serialize correctly; pagination fields exposed                                                | Contract test + sandbox run                                        |
+| On-ramp tracking | Get on-ramp                                 | ID is URL encoded; lifecycle fields documented                                                             | Contract test                                                      |
+| Returns          | Simulate `R01`                              | Deposit reaches returned path; return record exists                                                        | Sandbox run                                                        |
+| Returns          | Simulate `R10`                              | Unauthorized bucket/user action path covered                                                               | Sandbox run                                                        |
+| Returns          | Simulate `R29`                              | Corporate unauthorized path covered                                                                        | Sandbox run                                                        |
+| Returns          | List filters                                | `returnCode`, `returnBucket`, `lossOnly`, `userAction`, date bounds, pagination serialize correctly        | Contract test + sandbox run                                        |
+| Returns          | Get return by ID                            | ID is URL encoded; return fields exposed                                                                   | Contract test                                                      |
+| Webhooks         | Create webhook                              | Webhook can be registered for ACH-relevant public event names against a real HTTPS receiver                | Contract test + sandbox run                                        |
+| Webhooks         | Configure secret                            | Webhook secret is configured before event testing                                                          | Contract test + sandbox run                                        |
+| Webhooks         | Verify signature                            | Receiver validates HMAC signature using raw request body                                                   | Local receiver test + sandbox run                                  |
+| Webhooks         | Receive deposit event                       | Public webhook event for the ACH/on-ramp lifecycle is delivered after sandbox deposit creation             | Sandbox run                                                        |
+| Webhooks         | Receive return event                        | Public webhook event for ACH return handling is delivered after sandbox return simulation                  | Sandbox run                                                        |
+| Webhooks         | List/delete webhook                         | Webhook appears in list and can be deleted during cleanup                                                  | Contract test + sandbox run                                        |
+| Auth             | Bad bearer token                            | Throws `AuthenticationError` with clear message and IDs                                                    | Error test                                                         |
+| Auth             | Missing/invalid HMAC                        | Throws clean auth/permission error                                                                         | Error test                                                         |
+| Auth             | Feature disabled                            | Throws `PermissionDeniedError` with clear message                                                          | Error test                                                         |
+| Reliability      | Timeout                                     | Throws `APIConnectionTimeoutError`                                                                         | Unit test                                                          |
+| Reliability      | Network failure                             | Throws `APIConnectionError` with cause                                                                     | Unit test                                                          |
+| Reliability      | 429                                         | Throws `RateLimitError` with clean retry context if provided                                               | Error test                                                         |
+| Reliability      | 500                                         | Throws `InternalServerError`; request/trace IDs preserved                                                  | Error test                                                         |
 
 ## Plaid Signal QC
 
-Signal must be evaluated before ACH debit initiation. A blocked or rerouted Signal result must not create or submit a debit.
+Signal is evaluated during deposit creation after user confirmation and before ACH debit initiation. A blocked or rerouted Signal result must not create or submit a debit.
 
 Required behavior matrix:
 
-| Signal Scenario                | Expected Product Behavior                                   | Required Evidence        |
-| ------------------------------ | ----------------------------------------------------------- | ------------------------ |
-| Low risk                       | Deposit can be created normally                             | Simulation + sandbox run |
-| Medium risk                    | Behavior matches product policy exactly                     | Simulation + sandbox run |
-| High risk / reroute            | Deposit creation is blocked before ACH initiation           | Simulation + sandbox run |
-| Signal timeout                 | Deterministic fallback; no ambiguous partial initiation     | Error/simulation test    |
-| Signal unavailable             | Deterministic fallback; clean operational error if blocking | Error/simulation test    |
-| Null score / insufficient data | Deterministic fallback; partner-visible reason is clear     | Error/simulation test    |
-| Ruleset misconfigured          | Clean configuration error                                   | Error/simulation test    |
+| Signal Scenario                | Expected Product Behavior                                | Required Evidence             |
+| ------------------------------ | -------------------------------------------------------- | ----------------------------- |
+| Low risk                       | Deposit can be created normally                          | Simulation + sandbox run      |
+| Medium risk                    | Behavior matches product policy exactly                  | Simulation + sandbox run      |
+| High risk / reroute            | Deposit creation is blocked before ACH initiation        | Simulation or backend fixture |
+| Signal timeout                 | Deterministic fallback; no ambiguous partial initiation  | Error/simulation test         |
+| Signal unavailable             | 409 `risk_evaluation_unavailable`; no debit is initiated | Error/simulation test         |
+| Null score / insufficient data | 409 `risk_evaluation_unavailable`; no debit is initiated | Error/simulation test         |
+| Ruleset misconfigured          | Clean configuration error or unavailable-path response   | Error/simulation test         |
 
 Recommended sandbox API design:
 
 ```typescript
-await client.sandbox.createDepositWithSignalSimulation({
+await client.sandbox.createDepositWithReturn({
     preparationId,
-    signalSimulation: { outcome: 'reroute' },
+    signal: { outcome: 'reroute' },
 })
 ```
 
@@ -138,7 +166,7 @@ If combined simulations are needed for end-to-end cases, make the ordering expli
 ```typescript
 await client.sandbox.createDepositWithReturn({
     preparationId,
-    signalSimulation: { outcome: 'accept' },
+    signal: { outcome: 'accept' },
     returnSimulation: { code: 'R01' },
 })
 ```
@@ -262,18 +290,18 @@ Docs must clearly state:
 
 Complete this section when executing the plan.
 
-| Gate                          | Status  | Evidence |
-| ----------------------------- | ------- | -------- |
-| Automated checks              | Pending |          |
-| ACH contract tests            | Pending |          |
-| Error surfacing tests         | Pending |          |
-| Funding source deposit limits | Pending |          |
-| Signal simulations            | Pending |          |
-| Webhook E2E                   | Pending |          |
-| Live sandbox happy path       | Pending |          |
-| Live sandbox return paths     | Pending |          |
-| Docs review                   | Pending |          |
-| API gaps resolved/excluded    | Pending |          |
+| Gate                          | Status  | Evidence                                                           |
+| ----------------------------- | ------- | ------------------------------------------------------------------ |
+| Automated checks              | Pending |                                                                    |
+| ACH contract tests            | Pending |                                                                    |
+| Error surfacing tests         | Pending |                                                                    |
+| Funding source deposit limits | Pending |                                                                    |
+| Signal simulations            | Pending | Wire/verify sandbox `signal` selector in SDK contract              |
+| Webhook E2E                   | Blocked | Public ACH webhook event mapping not confirmed in platform/OpenAPI |
+| Live sandbox happy path       | Pending |                                                                    |
+| Live sandbox return paths     | Pending |                                                                    |
+| Docs review                   | Pending |                                                                    |
+| API gaps resolved/excluded    | Pending |                                                                    |
 
 Final release decision:
 

--- a/qc/ach-debit-release-qc.md
+++ b/qc/ach-debit-release-qc.md
@@ -1,0 +1,279 @@
+# ACH Debit Release QC Plan
+
+## Goal
+
+Prove the ACH debit SDK flow is ready for a paying partner to integrate, use, and debug without Spritz hand-holding.
+
+This plan covers:
+
+- Functional correctness across the full ACH debit lifecycle
+- SDK contract quality and type safety
+- Clean partner-facing error behavior
+- Plaid Signal risk-scoring behavior before debit initiation
+- Sandbox evidence for happy paths, blocked paths, and return paths
+- Documentation readiness
+
+## Release Gate
+
+Do not sign off until every item below is either complete or explicitly excluded with a named owner and reason.
+
+- `yarn agent:check` passes.
+- ACH SDK contract tests exist and pass.
+- Error surfacing tests exist and pass for RFC 7807 responses.
+- Live sandbox certification is complete.
+- Funding source deposit limits are exposed through the SDK and verified in sandbox.
+- Plaid Signal low, medium, high, unavailable, and null-score paths are covered.
+- Webhook setup, signing, delivery, and cleanup are verified end-to-end.
+- ACH return simulations are covered for at least `R01`, `R10`, and `R29`.
+- Partner docs/examples compile and match the SDK.
+- Any backend/API gaps are closed or called out as non-release scope.
+
+## Scope
+
+Partner-facing SDK surface:
+
+- `client.bankAccount.createLinkToken()`
+- `client.bankAccount.completeLinking(...)`
+- `client.fundingSource.list()`
+- `client.fundingSource.get(id)`
+- `client.fundingSource.getDepositLimits(id)`
+- `client.deposit.prepare(...)`
+- `client.deposit.create(...)`
+- `client.onrampPayment.list(...)`
+- `client.onrampPayment.get(id)`
+- `client.achDebitReturn.list(...)`
+- `client.achDebitReturn.get(id)`
+- `client.sandbox.bypassKyc(...)`
+- `client.sandbox.createDepositWithReturn(...)`
+- `client.webhook.create(...)`
+- `client.webhook.updateWebhookSecret(...)`
+- `client.webhook.list()`
+- `client.webhook.delete(id)`
+- Signal simulation support, if added
+
+Open scope questions:
+
+- What exact product behavior should medium-risk Signal produce: allow, review, delayed release, or block?
+
+## QC Matrix
+
+| Area             | Scenario                                    | Expected SDK/API Behavior                                                                                  | Required Evidence                    |
+| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Client setup     | Missing `apiKey` and `integrationKey`       | Constructor throws clear credential error                                                                  | Unit test                            |
+| Client setup     | `integratorSecret` without `integrationKey` | Constructor throws clear HMAC config error                                                                 | Unit test                            |
+| Client setup     | Browser without `dangerouslyAllowBrowser`   | Constructor blocks secret exposure                                                                         | Unit test                            |
+| Bank linking     | Create Plaid link token                     | Calls `POST /v1/bank-accounts/link-token`; returns `linkToken`, `hostedLinkUrl`, `expiration`              | Contract test                        |
+| Bank linking     | Complete Plaid Link                         | Calls `POST /v1/bank-accounts/link-complete`; sends `publicToken`, `accountIds`, institution metadata      | Contract test + sandbox run          |
+| Funding source   | List empty sources                          | Returns empty array; docs tell partner to link bank                                                        | Contract test                        |
+| Funding source   | Pending source                              | SDK surfaces `pending`; partner should retry/poll                                                          | Contract test + docs                 |
+| Funding source   | Active source                               | SDK surfaces source usable for prepare                                                                     | Contract test + sandbox run          |
+| Funding source   | Ineligible/review/disabled source           | Prepare/create does not proceed; error is clear                                                            | Contract test + sandbox/error test   |
+| Funding source   | Get by ID with unsafe chars                 | ID is URL encoded                                                                                          | Contract test                        |
+| Funding source   | Get deposit limits                          | Calls `GET /v1/funding-sources/{id}/deposit-limits`; exposes transaction, daily, monthly, unsettled limits | Contract test + sandbox run          |
+| Deposit prepare  | Exact input quote                           | Sends expected body; returns `preparationId`, `message`, `summary`                                         | Contract test                        |
+| Deposit prepare  | Exact output quote                          | Sends expected body; amount semantics documented                                                           | Contract test                        |
+| Deposit prepare  | Fee subsidy                                 | Sends `feeSubsidy`; response exposes gross/user/subsidy fields                                             | Contract test                        |
+| Deposit prepare  | Client context                              | Sends `clientContext` unchanged                                                                            | Contract test                        |
+| Deposit prepare  | Invalid wallet                              | Throws clean validation/problem error                                                                      | Error test + sandbox/API check       |
+| Deposit prepare  | Inactive funding source                     | Throws clean state/eligibility error                                                                       | Error test                           |
+| Authorization    | ACH authorization message                   | Partner must display `message` verbatim before create                                                      | Docs review + sandbox screenshot     |
+| Deposit create   | Happy path                                  | Calls `POST /v1/deposits/direct`; returns deposit lifecycle fields                                         | Contract test + sandbox run          |
+| Deposit create   | Expired preparation                         | Throws clean expired preparation error                                                                     | Error test                           |
+| Deposit create   | Reused preparation                          | Throws clean conflict/idempotency error                                                                    | Error test                           |
+| Deposit create   | High-risk Signal                            | No ACH debit is initiated; SDK error is actionable                                                         | Signal simulation + sandbox evidence |
+| On-ramp tracking | List on-ramps                               | Query params serialize correctly; pagination fields exposed                                                | Contract test + sandbox run          |
+| On-ramp tracking | Get on-ramp                                 | ID is URL encoded; lifecycle fields documented                                                             | Contract test                        |
+| Returns          | Simulate `R01`                              | Deposit reaches returned path; return record exists                                                        | Sandbox run                          |
+| Returns          | Simulate `R10`                              | Unauthorized bucket/user action path covered                                                               | Sandbox run                          |
+| Returns          | Simulate `R29`                              | Corporate unauthorized path covered                                                                        | Sandbox run                          |
+| Returns          | List filters                                | `returnCode`, `returnBucket`, `lossOnly`, `userAction`, date bounds, pagination serialize correctly        | Contract test + sandbox run          |
+| Returns          | Get return by ID                            | ID is URL encoded; return fields exposed                                                                   | Contract test                        |
+| Webhooks         | Create webhook                              | Webhook can be registered for ACH-relevant events against a real HTTPS receiver                            | Contract test + sandbox run          |
+| Webhooks         | Configure secret                            | Webhook secret is configured before event testing                                                          | Contract test + sandbox run          |
+| Webhooks         | Verify signature                            | Receiver validates HMAC signature using raw request body                                                   | Local receiver test + sandbox run    |
+| Webhooks         | Receive deposit event                       | Deposit lifecycle event is delivered after sandbox deposit creation                                        | Sandbox run                          |
+| Webhooks         | Receive return event                        | Return-related event is delivered after sandbox return simulation                                          | Sandbox run                          |
+| Webhooks         | List/delete webhook                         | Webhook appears in list and can be deleted during cleanup                                                  | Contract test + sandbox run          |
+| Auth             | Bad bearer token                            | Throws `AuthenticationError` with clear message and IDs                                                    | Error test                           |
+| Auth             | Missing/invalid HMAC                        | Throws clean auth/permission error                                                                         | Error test                           |
+| Auth             | Feature disabled                            | Throws `PermissionDeniedError` with clear message                                                          | Error test                           |
+| Reliability      | Timeout                                     | Throws `APIConnectionTimeoutError`                                                                         | Unit test                            |
+| Reliability      | Network failure                             | Throws `APIConnectionError` with cause                                                                     | Unit test                            |
+| Reliability      | 429                                         | Throws `RateLimitError` with clean retry context if provided                                               | Error test                           |
+| Reliability      | 500                                         | Throws `InternalServerError`; request/trace IDs preserved                                                  | Error test                           |
+
+## Plaid Signal QC
+
+Signal must be evaluated before ACH debit initiation. A blocked or rerouted Signal result must not create or submit a debit.
+
+Required behavior matrix:
+
+| Signal Scenario                | Expected Product Behavior                                   | Required Evidence        |
+| ------------------------------ | ----------------------------------------------------------- | ------------------------ |
+| Low risk                       | Deposit can be created normally                             | Simulation + sandbox run |
+| Medium risk                    | Behavior matches product policy exactly                     | Simulation + sandbox run |
+| High risk / reroute            | Deposit creation is blocked before ACH initiation           | Simulation + sandbox run |
+| Signal timeout                 | Deterministic fallback; no ambiguous partial initiation     | Error/simulation test    |
+| Signal unavailable             | Deterministic fallback; clean operational error if blocking | Error/simulation test    |
+| Null score / insufficient data | Deterministic fallback; partner-visible reason is clear     | Error/simulation test    |
+| Ruleset misconfigured          | Clean configuration error                                   | Error/simulation test    |
+
+Recommended sandbox API design:
+
+```typescript
+await client.sandbox.createDepositWithSignalSimulation({
+    preparationId,
+    signalSimulation: { outcome: 'reroute' },
+})
+```
+
+Keep Signal simulation separate from return simulation because Signal happens before debit initiation and returns happen after debit initiation.
+
+If combined simulations are needed for end-to-end cases, make the ordering explicit:
+
+```typescript
+await client.sandbox.createDepositWithReturn({
+    preparationId,
+    signalSimulation: { outcome: 'accept' },
+    returnSimulation: { code: 'R01' },
+})
+```
+
+Do not expose Plaid sandbox magic amounts as the partner workflow. They can be used internally to validate Signal rules, but partner-facing simulation should describe business outcomes such as `accept`, `review`, and `reroute`.
+
+## Automated Test Plan
+
+Add ACH-focused Vitest/MSW coverage.
+
+Test files:
+
+- `src/modules/bankAccount/bankAccountService.test.ts`
+- `src/modules/fundingSource/fundingSourceService.test.ts`
+- `src/modules/deposit/depositService.test.ts`
+- `src/modules/onrampPayment/onrampPaymentService.test.ts`
+- `src/modules/achDebitReturn/achDebitReturnService.test.ts`
+- `src/modules/sandbox/sandboxService.test.ts`
+- `src/modules/webhook/webhookService.test.ts`
+- `src/lib/error.test.ts`
+- optional compile-only type test for public exports
+
+Coverage requirements:
+
+- Correct method/path for each SDK call.
+- Correct query serialization.
+- Correct path encoding.
+- Correct body passthrough.
+- HMAC headers attached for signed REST calls.
+- Request body is signed exactly as sent.
+- Funding-source deposit limit response fields are available through public SDK types.
+- Webhook create/list/delete/secret methods are covered by SDK tests.
+- RFC 7807 errors produce clean `error.message` values.
+- Error subclasses match HTTP status.
+- Response headers preserve request/trace IDs.
+- Public types are exported from `src/index.ts`.
+
+## Error Quality Standard
+
+Partner-facing errors should be concise, actionable, and classifiable.
+
+Minimum standard:
+
+- `error.name` maps to the HTTP class where possible.
+- `error.status` is populated for HTTP errors.
+- `error.message` prefers RFC 7807 `detail`, then `title`, then `message`, then a safe fallback.
+- `error.headers.requestId` and `error.headers.traceId` are available when returned.
+- Raw JSON stringification should not be the default partner experience.
+
+Required error fixtures:
+
+- 400 invalid input
+- 401 missing/invalid bearer token
+- 403 feature disabled
+- 404 funding source not found
+- 409 expired/reused preparation
+- 422 invalid state, if emitted by API
+- 429 rate limit
+- 500 internal error
+- non-JSON error response
+- network failure
+- timeout
+
+## Live Sandbox Certification
+
+Run this with real sandbox credentials and save evidence.
+
+1. Create or select a test user.
+2. Bypass KYC with `client.sandbox.bypassKyc({ country: 'US' })`.
+3. Create Plaid link token.
+4. Complete Plaid Link with sandbox credentials.
+5. Poll funding sources until an `active` source exists.
+6. Fetch deposit limits with `client.fundingSource.getDepositLimits(source.id)`.
+7. Start a real HTTPS webhook receiver that records raw body, headers, and parsed payload.
+8. Set webhook secret with `client.webhook.updateWebhookSecret(...)`.
+9. Register webhook with `client.webhook.create(...)`.
+10. Confirm webhook appears in `client.webhook.list()`.
+11. Prepare low-risk deposit.
+12. Verify quote fields and authorization message.
+13. Create low-risk deposit.
+14. Confirm on-ramp appears in `client.onrampPayment.list()`.
+15. Fetch on-ramp by ID.
+16. Confirm webhook receiver gets the expected deposit/on-ramp lifecycle event.
+17. Verify webhook signature against the raw request body.
+18. Run medium-risk Signal scenario and verify policy behavior.
+19. Run high-risk Signal scenario and verify no ACH debit is initiated.
+20. Run Signal timeout/unavailable/null-score scenarios if sandbox supports them.
+21. Simulate `R01` return.
+22. Simulate `R10` return.
+23. Simulate `R29` return.
+24. Confirm each return appears in `client.achDebitReturn.list()`.
+25. Fetch each return by ID.
+26. Confirm webhook receiver gets expected return-related events.
+27. Verify return filters and pagination.
+28. Delete the webhook and verify it no longer appears in `client.webhook.list()`.
+29. Capture request IDs, deposit IDs, on-ramp IDs, return IDs, webhook IDs, received event payloads, and relevant screenshots/log excerpts.
+
+## Documentation Review
+
+Review these before sign-off:
+
+- `README.md`
+- `docs/ach-onramp-guide.md`
+- `scripts/sandbox/ach-onramp.html`
+- package public exports in `src/index.ts`
+
+Docs must clearly state:
+
+- SDK calls are server-side only.
+- Integrator secret must never be sent to production clients.
+- Plaid Link UI is client-side only.
+- Funding source must be `active` before deposit prepare.
+- Deposit limits should be fetched and handled before collecting final user authorization.
+- Authorization message must be shown verbatim.
+- Signal can block before ACH initiation.
+- Return simulation is sandbox-only.
+- Sandbox-only APIs return 403 in production.
+- Webhook setup is part of the integration, with signature verification documented.
+
+## Sign-Off Record
+
+Complete this section when executing the plan.
+
+| Gate                          | Status  | Evidence |
+| ----------------------------- | ------- | -------- |
+| Automated checks              | Pending |          |
+| ACH contract tests            | Pending |          |
+| Error surfacing tests         | Pending |          |
+| Funding source deposit limits | Pending |          |
+| Signal simulations            | Pending |          |
+| Webhook E2E                   | Pending |          |
+| Live sandbox happy path       | Pending |          |
+| Live sandbox return paths     | Pending |          |
+| Docs review                   | Pending |          |
+| API gaps resolved/excluded    | Pending |          |
+
+Final release decision:
+
+- Decision: Pending
+- Owner:
+- Date:
+- Notes:

--- a/qc/ach-debit-release-qc.md
+++ b/qc/ach-debit-release-qc.md
@@ -28,6 +28,24 @@ Do not sign off until every item below is either complete or explicitly excluded
 - Partner docs/examples compile and match the SDK.
 - Any backend/API gaps are closed or called out as non-release scope.
 
+## Findings To Carry Into Sign-Off
+
+These are the concrete things identified during QC and must stay visible until release:
+
+- The partner will consume ACH debit through the generated SDK. REST parity is useful for debugging, but release sign-off is based on SDK behavior, SDK error classes, SDK types, and SDK docs.
+- The flow is intentionally small: create/link bank account, choose an `active` funding source, fetch limits, prepare, show authorization text, create, then track by webhook plus `onrampPayment`/`achDebitReturn`.
+- `GET /v1/funding-sources/{id}/deposit-limits` must be exposed by the SDK and verified in sandbox before release.
+- Plaid Signal is not a public request field. It runs after user confirmation during `client.deposit.create(...)`, before Spritz submits the ACH pull.
+- Plaid Signal sandbox simulation is amount-driven. The SDK must not invent a `signal` field that is not in the OpenAPI contract.
+- Error quality is release-critical. The SDK must surface clear subclasses, status codes, problem details, request IDs, and actionable messages.
+- Webhook setup is part of partner release scope. Polling through `onrampPayment` and `achDebitReturn` is required for reconciliation, but not enough for the production integration.
+- ACH webhook public event scope is `onramp.created`, `onramp.updated`, `onramp.completed`, `achDebitReturn.created`, `achDebitReturn.updated`, and `*` for all events. Internal event names may be transformed, but the consumer-facing webhook contract must not break.
+- Return simulation is post-authorization and sandbox-only. It should use `client.sandbox.createDepositWithReturn(...)`, not a normal create call.
+- Current staging blocker found on 2026-05-07: authorized ACH deposits are not auto-progressing because `DepositCreatedSubscriber` and `DepositExecutionLoop` crash on an unlinked `PlaidWebhookUrl` resource at startup. This does not mean ACH requires Plaid webhooks; it is a platform configuration/layer-coupling bug that must be fixed and redeployed before webhook/settlement certification.
+- Webhook E2E was manually verified for non-return events in staging on 2026-05-07. Return webhook receipt still needs explicit confirmation after a simulated return.
+- R01 return simulation was verified through the SDK on 2026-05-08: deposit `dep_01KR3DBTDDFEZ8FBMC0EVQVVH0`, return `dr_01KR3DDAQYERAAMWXMCT32RBBE`, on-ramp `69fda76d13a0c32a6571c786`, source `fs_01KR16ZM37E2JTBC19P8RXFV8R` disabled with reason `returned`.
+- Potential API gap found on 2026-05-08: `client.achDebitReturn.list({ search: depositId })` returned no rows for public deposit ID `dep_01KR3DBTDDFEZ8FBMC0EVQVVH0`, but `client.achDebitReturn.list({ returnCode: 'R01' })` returned the matching return. Confirm whether `search` should support public deposit IDs and fix if yes.
+
 ## Scope
 
 Partner-facing SDK surface:
@@ -49,11 +67,7 @@ Partner-facing SDK surface:
 - `client.webhook.updateWebhookSecret(...)`
 - `client.webhook.list()`
 - `client.webhook.delete(id)`
-- Signal simulation support, if added
-
-Open scope questions:
-
-- What exact Signal fixture should represent partner-facing "medium risk": a Plaid ruleset `review` outcome, or an accepted score below Spritz's local block threshold?
+- `client.user.create(...)` or equivalent user creation path used by the example app to generate a sandbox user API key
 
 Confirmed product behavior:
 
@@ -61,11 +75,13 @@ Confirmed product behavior:
 - A blocked/rerouted Signal result must return a clean 409 error and must not create or submit an ACH debit.
 - Signal `review` maps to `risk_review_required`; `reject`, `reroute`, and local-threshold blocks map to `risk_rejected`; unavailable/insufficient data maps to `risk_evaluation_unavailable`.
 - A blocked create attempt consumes the preparation. The partner must prepare a new quote after resolving the issue, not retry the same `preparationId`.
+- Staging should automatically move accepted deposits through the async ACH lifecycle once the deposit is authorized. If a deposit remains `authorized` with no Modern Treasury submission, inspect the deposit execution subscribers before treating webhook delivery as the issue.
 
 Known API gaps to resolve before sign-off:
 
-- Signal simulation is partner-release scope and should use the sandbox `signal` selector. The SDK/OpenAPI contract in this worktree must be refreshed or extended so `client.sandbox.createDepositWithReturn(...)` accepts it with strong types.
-- The generated webhook event enum currently exposes legacy account/payment/capability events only. Platform emits internal ACH events such as `deposit.created`, `deposit.updated`, `deposit-return.created`, and `deposit-return.updated`, but this repo does not show a public webhook subscription/delivery contract for those ACH events. Confirm whether legacy `payment.*` events are the intended public mapping, or update the backend/OpenAPI contract before E2E webhook certification.
+- The generated webhook event enum must include the ACH partner events: `onramp.created`, `onramp.updated`, `onramp.completed`, `achDebitReturn.created`, `achDebitReturn.updated`, and `*`.
+- Webhook payloads and endpoint behavior must remain backward compatible for existing consumers. If platform internal events differ, transform them before delivery rather than changing the public contract.
+- Platform staging must be fixed so `DepositCreatedSubscriber` and `DepositExecutionLoop` can start without requiring unrelated Plaid webhook resource linkage.
 
 ## Backend Contract Check
 
@@ -84,8 +100,7 @@ Create order:
 Sandbox reality:
 
 - `/v1/sandbox/deposits` and `/v1/sandbox/deposits/direct` support `returnSimulation.code`.
-- Signal simulation should be exposed as `signal` on the sandbox create payload.
-- The current generated SDK types only show `returnSimulation`, so SDK contract work is still required before sign-off.
+- Signal sandbox behavior is exercised through Plaid amount fixtures; there is no public SDK `signal` field.
 
 ## QC Matrix
 
@@ -123,8 +138,8 @@ Sandbox reality:
 | Webhooks         | Create webhook                              | Webhook can be registered for ACH-relevant public event names against a real HTTPS receiver                | Contract test + sandbox run                                        |
 | Webhooks         | Configure secret                            | Webhook secret is configured before event testing                                                          | Contract test + sandbox run                                        |
 | Webhooks         | Verify signature                            | Receiver validates HMAC signature using raw request body                                                   | Local receiver test + sandbox run                                  |
-| Webhooks         | Receive deposit event                       | Public webhook event for the ACH/on-ramp lifecycle is delivered after sandbox deposit creation             | Sandbox run                                                        |
-| Webhooks         | Receive return event                        | Public webhook event for ACH return handling is delivered after sandbox return simulation                  | Sandbox run                                                        |
+| Webhooks         | Receive on-ramp events                      | `onramp.created` and `onramp.updated` are delivered after sandbox deposit creation and lifecycle updates   | Sandbox run                                                        |
+| Webhooks         | Receive return events                       | `achDebitReturn.created` and `achDebitReturn.updated` are delivered after sandbox return simulation        | Sandbox run                                                        |
 | Webhooks         | List/delete webhook                         | Webhook appears in list and can be deleted during cleanup                                                  | Contract test + sandbox run                                        |
 | Auth             | Bad bearer token                            | Throws `AuthenticationError` with clear message and IDs                                                    | Error test                                                         |
 | Auth             | Missing/invalid HMAC                        | Throws clean auth/permission error                                                                         | Error test                                                         |
@@ -150,28 +165,25 @@ Required behavior matrix:
 | Null score / insufficient data | 409 `risk_evaluation_unavailable`; no debit is initiated | Error/simulation test         |
 | Ruleset misconfigured          | Clean configuration error or unavailable-path response   | Error/simulation test         |
 
-Recommended sandbox API design:
+Sandbox Signal testing is amount-driven. The generated SDK must not expose a
+`signal` request field because it is not in the public OpenAPI contract.
+
+Use Plaid's sandbox amount fixtures:
+
+| Amount  | Plaid Signal score | Expected Spritz use                                  |
+| ------- | ------------------ | ---------------------------------------------------- |
+| `3.53`  | `10`               | Low score; below current ACH minimum in this sandbox |
+| `12.17` | `60`               | Medium score; expected allow under local threshold   |
+| `27.53` | `90`               | High score; expected pre-debit risk block            |
+
+Return simulation remains explicit and post-authorization:
 
 ```typescript
 await client.sandbox.createDepositWithReturn({
     preparationId,
-    signal: { outcome: 'reroute' },
-})
-```
-
-Keep Signal simulation separate from return simulation because Signal happens before debit initiation and returns happen after debit initiation.
-
-If combined simulations are needed for end-to-end cases, make the ordering explicit:
-
-```typescript
-await client.sandbox.createDepositWithReturn({
-    preparationId,
-    signal: { outcome: 'accept' },
     returnSimulation: { code: 'R01' },
 })
 ```
-
-Do not expose Plaid sandbox magic amounts as the partner workflow. They can be used internally to validate Signal rules, but partner-facing simulation should describe business outcomes such as `accept`, `review`, and `reroute`.
 
 ## Automated Test Plan
 
@@ -213,6 +225,7 @@ Minimum standard:
 - `error.name` maps to the HTTP class where possible.
 - `error.status` is populated for HTTP errors.
 - `error.message` prefers RFC 7807 `detail`, then `title`, then `message`, then a safe fallback.
+- `error.error` preserves the parsed RFC 7807 payload for requirements, problem type, and partner support diagnostics.
 - `error.headers.requestId` and `error.headers.traceId` are available when returned.
 - Raw JSON stringification should not be the default partner experience.
 
@@ -234,35 +247,39 @@ Required error fixtures:
 
 Run this with real sandbox credentials and save evidence.
 
-1. Create or select a test user.
-2. Bypass KYC with `client.sandbox.bypassKyc({ country: 'US' })`.
-3. Create Plaid link token.
-4. Complete Plaid Link with sandbox credentials.
-5. Poll funding sources until an `active` source exists.
-6. Fetch deposit limits with `client.fundingSource.getDepositLimits(source.id)`.
-7. Start a real HTTPS webhook receiver that records raw body, headers, and parsed payload.
-8. Set webhook secret with `client.webhook.updateWebhookSecret(...)`.
-9. Register webhook with `client.webhook.create(...)`.
-10. Confirm webhook appears in `client.webhook.list()`.
-11. Prepare low-risk deposit.
-12. Verify quote fields and authorization message.
-13. Create low-risk deposit.
-14. Confirm on-ramp appears in `client.onrampPayment.list()`.
-15. Fetch on-ramp by ID.
-16. Confirm webhook receiver gets the expected deposit/on-ramp lifecycle event.
-17. Verify webhook signature against the raw request body.
-18. Run medium-risk Signal scenario and verify policy behavior.
-19. Run high-risk Signal scenario and verify no ACH debit is initiated.
-20. Run Signal timeout/unavailable/null-score scenarios if sandbox supports them.
-21. Simulate `R01` return.
-22. Simulate `R10` return.
-23. Simulate `R29` return.
-24. Confirm each return appears in `client.achDebitReturn.list()`.
-25. Fetch each return by ID.
-26. Confirm webhook receiver gets expected return-related events.
-27. Verify return filters and pagination.
-28. Delete the webhook and verify it no longer appears in `client.webhook.list()`.
-29. Capture request IDs, deposit IDs, on-ramp IDs, return IDs, webhook IDs, received event payloads, and relevant screenshots/log excerpts.
+1. Generate a fresh sandbox user API key through the SDK/example app.
+2. Before KYC bypass, call `client.bankAccount.createLinkToken()` and confirm the SDK throws `PermissionDeniedError` with status `403`, request IDs, and the identity-verification requirement body.
+3. Bypass KYC with `client.sandbox.bypassKyc({ country: 'US' })`.
+4. Retry `client.bankAccount.createLinkToken()` and confirm success.
+5. Complete Plaid Link with sandbox credentials in the browser.
+6. Poll `client.fundingSource.list()` until an `active` source exists.
+7. Fetch `client.fundingSource.get(source.id)` and verify path encoding and source fields.
+8. Fetch `client.fundingSource.getDepositLimits(source.id)` and verify transaction, daily, monthly, and unsettled-limit fields.
+9. Start a real HTTPS webhook receiver that records raw body, headers, parsed payload, signature verification result, and receipt timestamp.
+10. Set webhook secret with `client.webhook.updateWebhookSecret(...)`.
+11. Register webhook with `client.webhook.create(...)` for `onramp.created`, `onramp.updated`, `achDebitReturn.created`, and `achDebitReturn.updated`.
+12. Confirm webhook appears in `client.webhook.list()`.
+13. Prepare a low/medium-risk deposit using the Plaid score `60` amount fixture.
+14. Verify quote fields, fees, destination, limits snapshot if returned, and the full ACH authorization message.
+15. Confirm in the UI, then create with `client.deposit.create(...)`.
+16. Confirm the SDK response is clean and the deposit/on-ramp IDs are recorded.
+17. Confirm `onramp.created` and `onramp.updated` are received and signature verification passes against the raw request body.
+18. Confirm the on-ramp appears in `client.onrampPayment.list(...)`.
+19. Fetch the on-ramp by ID with `client.onrampPayment.get(id)`.
+20. Confirm the deposit leaves `authorized` and progresses through the staging async lifecycle after platform workers run.
+21. Run high-risk Plaid Signal using the score `90` amount fixture and verify a clean 409, no ACH debit initiation, and no MT payment order.
+22. Run Signal unavailable/null-score coverage if the sandbox fixture exists; otherwise record as excluded with platform owner and reason.
+23. Simulate `R01` using `client.sandbox.createDepositWithReturn(...)`.
+24. Simulate `R10` using `client.sandbox.createDepositWithReturn(...)`.
+25. Simulate `R29` using `client.sandbox.createDepositWithReturn(...)`.
+26. Confirm each return appears in `client.achDebitReturn.list(...)`.
+27. Fetch each return by ID with `client.achDebitReturn.get(id)`.
+28. Confirm `achDebitReturn.created` and `achDebitReturn.updated` are received and signature verification passes.
+29. Verify return filters and pagination: `returnCode`, `returnBucket`, `lossOnly`, `userAction`, date bounds, `limit`, and `cursor`.
+30. Delete the webhook and verify it no longer appears in `client.webhook.list()`.
+31. Capture request IDs, deposit IDs, on-ramp IDs, return IDs, webhook IDs, received event payloads, signature results, evidence file names, and relevant log excerpts.
+
+All live sandbox certification must run through the SDK. Raw REST calls are allowed only as parity checks when debugging an SDK failure.
 
 ## Documentation Review
 
@@ -271,6 +288,7 @@ Review these before sign-off:
 - `README.md`
 - `docs/ach-onramp-guide.md`
 - `scripts/sandbox/ach-onramp.html`
+- `qc/ach-debit-example-app-e2e.md`
 - package public exports in `src/index.ts`
 
 Docs must clearly state:
@@ -290,18 +308,18 @@ Docs must clearly state:
 
 Complete this section when executing the plan.
 
-| Gate                          | Status  | Evidence                                                           |
-| ----------------------------- | ------- | ------------------------------------------------------------------ |
-| Automated checks              | Pending |                                                                    |
-| ACH contract tests            | Pending |                                                                    |
-| Error surfacing tests         | Pending |                                                                    |
-| Funding source deposit limits | Pending |                                                                    |
-| Signal simulations            | Pending | Wire/verify sandbox `signal` selector in SDK contract              |
-| Webhook E2E                   | Blocked | Public ACH webhook event mapping not confirmed in platform/OpenAPI |
-| Live sandbox happy path       | Pending |                                                                    |
-| Live sandbox return paths     | Pending |                                                                    |
-| Docs review                   | Pending |                                                                    |
-| API gaps resolved/excluded    | Pending |                                                                    |
+| Gate                          | Status  | Evidence                                                         |
+| ----------------------------- | ------- | ---------------------------------------------------------------- |
+| Automated checks              | Pending |                                                                  |
+| ACH contract tests            | Pending |                                                                  |
+| Error surfacing tests         | Pending |                                                                  |
+| Funding source deposit limits | Pending |                                                                  |
+| Signal simulations            | Pending | Amount-driven Plaid sandbox fixtures; run sandbox evidence       |
+| Webhook E2E                   | Partial | Non-return events verified; return webhook receipt still needed  |
+| Live sandbox happy path       | Pending |                                                                  |
+| Live sandbox return paths     | Partial | R01 verified via SDK on 2026-05-08; R10/R29 pending              |
+| Docs review                   | Pending |                                                                  |
+| API gaps resolved/excluded    | Pending | Webhook enum/events; staging `PlaidWebhookUrl` resource coupling |
 
 Final release decision:
 

--- a/scripts/sandbox/ach-onramp.html
+++ b/scripts/sandbox/ach-onramp.html
@@ -2,8 +2,7 @@
   ACH Onramp — Spritz Sandbox Demo
 
   Serve this file over HTTP (not file://):
-    npx serve scripts/sandbox
-    # or: python3 -m http.server -d scripts/sandbox
+    node scripts/sandbox/evidence-server.mjs
 
   Prerequisites:
     - A sandbox user with KYC bypassed (run: ./scripts/sandbox/run.sh setup-user)
@@ -140,6 +139,19 @@
                 opacity: 0.4;
                 cursor: not-allowed;
             }
+            button.secondary {
+                background: var(--border);
+                color: var(--text);
+            }
+            .button-row {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.5rem;
+                margin-top: 0.75rem;
+            }
+            .button-row button {
+                margin-top: 0;
+            }
             pre {
                 background: var(--bg);
                 border: 1px solid var(--border);
@@ -181,6 +193,11 @@
                 font-size: 0.8rem;
                 word-break: break-all;
             }
+            .evidence-note {
+                color: var(--muted);
+                font-size: 0.7rem;
+                margin-top: 0.75rem;
+            }
             select {
                 width: 100%;
                 background: var(--bg);
@@ -196,7 +213,10 @@
     </head>
     <body>
         <h1>ACH Onramp Demo</h1>
-        <p class="subtitle">Spritz Finance — Sandbox Environment</p>
+        <p class="subtitle">
+            Spritz Finance — Sandbox Environment — SDK QC build
+            <span id="appVersionLabel"></span>
+        </p>
 
         <div class="config">
             <p style="color: var(--yellow); font-size: 0.75rem; margin-bottom: 0.75rem">
@@ -206,17 +226,60 @@
             <input id="integrationKey" placeholder="ik_..." />
             <label>Integrator Secret</label>
             <input id="integratorSecret" type="password" placeholder="secret" />
+            <label>Sandbox User Email (optional)</label>
+            <input id="sandboxUserEmail" placeholder="ach-qc+timestamp@spritz.finance" />
             <label>API Key</label>
             <input id="apiKey" placeholder="ak_..." />
             <label>Destination Wallet (Solana, Base58)</label>
             <input id="walletAddress" placeholder="9xQeWvG816bUx9EPjHmaT23yvVMb..." />
             <label>Deposit Amount (USD)</label>
-            <input id="depositAmount" value="1.00" placeholder="1.00" />
+            <input id="depositAmount" value="12.17" placeholder="12.17" />
             <label>Fee Subsidy % (optional — integrator absorbs this % of the fee)</label>
             <input id="feeSubsidyPct" placeholder="e.g. 50" />
             <label>Max Fee Subsidy USD (optional — cap on subsidy per deposit)</label>
             <input id="feeSubsidyMax" placeholder="e.g. 5.00" />
-            <button onclick="startDemo()">Start</button>
+            <label>Plaid Signal Sandbox Amount Profile</label>
+            <select id="signalProfile">
+                <option value="score60">
+                    score 60 — $12.17, expected allow under local threshold
+                </option>
+                <option value="score90">score 90 — $27.53, expected risk block</option>
+                <option value="custom">custom amount — no hardcoded Signal score</option>
+            </select>
+            <label>Sandbox Return Code (optional)</label>
+            <input id="returnSimulationCode" placeholder="R01, R10, R29" />
+            <div class="button-row">
+                <button class="secondary" onclick="generateFreshUser()">Generate Fresh User</button>
+                <button class="secondary" onclick="bypassCurrentUserKyc()">Bypass KYC (US)</button>
+                <button class="secondary" onclick="runKycGateQc()">Full SDK KYC Gate QC</button>
+                <button onclick="startDemo()">Start</button>
+                <button
+                    class="secondary"
+                    id="downloadEvidenceBtn"
+                    onclick="downloadEvidence()"
+                    disabled
+                >
+                    Download Evidence
+                </button>
+                <button
+                    class="secondary"
+                    id="saveEvidenceBtn"
+                    onclick="saveEvidenceToWorkspace()"
+                    disabled
+                >
+                    Save Evidence to Workspace
+                </button>
+                <button class="secondary" id="copyEvidenceBtn" onclick="copyEvidence()" disabled>
+                    Copy Evidence
+                </button>
+                <button class="secondary" onclick="clearEvidence()">Clear Evidence</button>
+                <button class="secondary" onclick="clearSavedForm()">Clear Saved Form</button>
+            </div>
+            <p class="evidence-note">
+                Evidence export redacts credentials, HMAC signatures, Plaid public tokens, and link
+                tokens. Workspace saves go to <code>qc/evidence/</code> when the local receiver is
+                running. Sandbox form values are saved in this browser.
+            </p>
         </div>
 
         <div id="steps"></div>
@@ -224,84 +287,440 @@
 
         <script>
             const BASE = 'https://sandbox.spritz.finance'
+            const APP_VERSION = 'sdk-qc-2026-05-06-3'
+            const SIGNAL_DATA_READY_DELAY_MS = 20000
+            const SIGNAL_AMOUNT_PROFILES = {
+                score60: {
+                    amountUsd: '12.17',
+                    label: 'Plaid sandbox Signal score 60',
+                    expected: 'expected allow under local threshold',
+                },
+                score90: {
+                    amountUsd: '27.53',
+                    label: 'Plaid sandbox Signal score 90',
+                    expected: 'expected pre-debit risk block',
+                },
+                custom: {
+                    amountUsd: null,
+                    label: 'custom amount',
+                    expected: 'no hardcoded Signal score',
+                },
+            }
+            const EVIDENCE_STORAGE_KEY = 'spritz-ach-onramp-evidence'
+            const FORM_STORAGE_KEY = 'spritz-ach-onramp-form'
+            const EVIDENCE_RECEIVER = `${window.location.origin}/evidence`
+            const FORM_FIELD_IDS = [
+                'integrationKey',
+                'integratorSecret',
+                'sandboxUserEmail',
+                'apiKey',
+                'walletAddress',
+                'depositAmount',
+                'feeSubsidyPct',
+                'feeSubsidyMax',
+                'signalProfile',
+                'returnSimulationCode',
+            ]
 
-            // --- HMAC signing (mirrors src/lib/hmac.ts) ---
-            function hexEncode(buf) {
-                return Array.from(new Uint8Array(buf))
-                    .map((b) => b.toString(16).padStart(2, '0'))
-                    .join('')
-            }
-            async function sha256Hex(data) {
-                const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(data))
-                return hexEncode(hash)
-            }
-            async function hmacSha256Hex(secret, data) {
-                const enc = new TextEncoder()
-                const key = await crypto.subtle.importKey(
-                    'raw',
-                    enc.encode(secret),
-                    { name: 'HMAC', hash: 'SHA-256' },
-                    false,
-                    ['sign']
-                )
-                const sig = await crypto.subtle.sign('HMAC', key, enc.encode(data))
-                return hexEncode(sig)
-            }
-            async function stampRequest(integratorKey, integratorSecret, method, url, body) {
-                const parsed = new URL(url)
-                const params = [...parsed.searchParams.keys()].sort()
-                const qs = params
-                    .map(
-                        (k) =>
-                            `${encodeURIComponent(k)}=${encodeURIComponent(parsed.searchParams.get(k))}`
-                    )
-                    .join('&')
-                const path = qs ? `${parsed.pathname}?${qs}` : parsed.pathname
-                const timestamp = Date.now()
-                const bodyHash = body ? await sha256Hex(body) : ''
-                const payload = `${timestamp}.${method.toUpperCase()}.${path}.${bodyHash}`
-                const signature = `sha256=${await hmacSha256Hex(integratorSecret, payload)}`
-                return {
-                    'X-Integrator-Key': integratorKey,
-                    'X-Signature': signature,
-                    'X-Timestamp': String(timestamp),
-                }
+            // --- Evidence capture ---
+            let evidence = null
+
+            function nowIso() {
+                return new Date().toISOString()
             }
 
-            // --- API client ---
-            async function api(method, path, body) {
-                const url = `${BASE}${path}`
-                const bodyStr = body ? JSON.stringify(body) : null
-                const cfg = getConfig()
-                const hmacHeaders = await stampRequest(
-                    cfg.integrationKey,
-                    cfg.integratorSecret,
-                    method,
-                    url,
-                    bodyStr
-                )
-                const headers = {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${cfg.apiKey}`,
-                    ...hmacHeaders,
-                }
-                let res
-                try {
-                    res = await fetch(url, { method, headers, body: bodyStr })
-                } catch (e) {
-                    throw new Error(
-                        `Network error — if running from file://, serve over HTTP instead (npx serve scripts/sandbox). Details: ${e.message}`
+            function redactString(value) {
+                if (value == null) return value
+                if (typeof value !== 'string' || value.length <= 8) return '[redacted]'
+                return `${value.slice(0, 4)}...${value.slice(-4)} [redacted]`
+            }
+
+            function shouldRedactKey(key) {
+                const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, '')
+                return [
+                    'apikey',
+                    'authorization',
+                    'integrationkey',
+                    'integratorkey',
+                    'integratorsecret',
+                    'secret',
+                    'signature',
+                    'linktoken',
+                    'publictoken',
+                    'rawkey',
+                    'accesstoken',
+                    'refreshtoken',
+                    'password',
+                ].some((sensitiveKey) => normalized === sensitiveKey)
+            }
+
+            function sanitizeEvidence(value, key = '') {
+                if (shouldRedactKey(key)) return redactString(value)
+                if (Array.isArray(value)) return value.map((item) => sanitizeEvidence(item))
+                if (value && typeof value === 'object') {
+                    return Object.fromEntries(
+                        Object.entries(value).map(([childKey, childValue]) => [
+                            childKey,
+                            sanitizeEvidence(childValue, childKey),
+                        ])
                     )
                 }
-                let json
+                return value
+            }
+
+            function getFormField(id) {
+                return document.getElementById(id)
+            }
+
+            function collectFormValues() {
+                return Object.fromEntries(
+                    FORM_FIELD_IDS.map((id) => [id, getFormField(id)?.value ?? ''])
+                )
+            }
+
+            function saveFormValues() {
+                localStorage.setItem(FORM_STORAGE_KEY, JSON.stringify(collectFormValues()))
+            }
+
+            function restoreFormValues() {
+                const raw = localStorage.getItem(FORM_STORAGE_KEY)
+                if (!raw) return
+
                 try {
-                    json = await res.json()
+                    const values = JSON.parse(raw)
+                    for (const id of FORM_FIELD_IDS) {
+                        const field = getFormField(id)
+                        if (field && typeof values[id] === 'string') field.value = values[id]
+                    }
                 } catch {
-                    throw new Error(`HTTP ${res.status} (non-JSON response)`)
+                    localStorage.removeItem(FORM_STORAGE_KEY)
                 }
-                if (!res.ok) throw new Error(json.detail || json.title || `HTTP ${res.status}`)
+            }
+
+            function bindFormPersistence() {
+                for (const id of FORM_FIELD_IDS) {
+                    const field = getFormField(id)
+                    if (!field) continue
+                    field.addEventListener('input', saveFormValues)
+                    field.addEventListener('change', saveFormValues)
+                }
+                getFormField('signalProfile')?.addEventListener('change', applySignalProfileAmount)
+            }
+
+            function clearSavedForm() {
+                localStorage.removeItem(FORM_STORAGE_KEY)
+                for (const id of FORM_FIELD_IDS) {
+                    const field = getFormField(id)
+                    if (!field) continue
+                    if (id === 'depositAmount') {
+                        field.value = SIGNAL_AMOUNT_PROFILES.score60.amountUsd
+                    } else if (id === 'signalProfile') {
+                        field.value = 'score60'
+                    } else {
+                        field.value = ''
+                    }
+                }
+                log('Saved form cleared')
+            }
+
+            function getRunInputs() {
+                return {
+                    integrationKey: document.getElementById('integrationKey').value.trim(),
+                    apiKey: document.getElementById('apiKey').value.trim(),
+                    sandboxUserEmail: document.getElementById('sandboxUserEmail').value.trim(),
+                    walletAddress: document.getElementById('walletAddress').value.trim(),
+                    depositAmount: document.getElementById('depositAmount').value.trim(),
+                    feeSubsidyPct: document.getElementById('feeSubsidyPct').value.trim(),
+                    feeSubsidyMax: document.getElementById('feeSubsidyMax').value.trim(),
+                    signalProfile: document.getElementById('signalProfile').value.trim(),
+                    returnSimulationCode: document
+                        .getElementById('returnSimulationCode')
+                        .value.trim(),
+                }
+            }
+
+            function initEvidence() {
+                const runId = `ach-qc-${new Date().toISOString().replace(/[:.]/g, '-')}`
+                evidence = {
+                    schemaVersion: 1,
+                    runId,
+                    app: 'scripts/sandbox/ach-onramp.html',
+                    appVersion: APP_VERSION,
+                    environment: 'sandbox',
+                    baseUrl: BASE,
+                    startedAt: nowIso(),
+                    browser: {
+                        userAgent: navigator.userAgent,
+                        language: navigator.language,
+                        platform: navigator.platform,
+                    },
+                    inputs: sanitizeEvidence(getRunInputs()),
+                    events: [],
+                }
+                persistEvidence()
+                updateEvidenceButtons()
+                recordEvidence('run.started', { inputs: getRunInputs() })
+            }
+
+            function persistEvidence() {
+                if (!evidence) return
+                localStorage.setItem(EVIDENCE_STORAGE_KEY, JSON.stringify(evidence))
+                updateEvidenceButtons()
+            }
+
+            function loadEvidence() {
+                const raw = localStorage.getItem(EVIDENCE_STORAGE_KEY)
+                if (!raw) return
+                try {
+                    evidence = JSON.parse(raw)
+                    updateEvidenceButtons()
+                } catch {
+                    localStorage.removeItem(EVIDENCE_STORAGE_KEY)
+                }
+            }
+
+            function updateEvidenceButtons() {
+                const hasEvidence = Boolean(evidence?.events?.length)
+                document.getElementById('downloadEvidenceBtn').disabled = !hasEvidence
+                document.getElementById('saveEvidenceBtn').disabled = !hasEvidence
+                document.getElementById('copyEvidenceBtn').disabled = !hasEvidence
+            }
+
+            function recordEvidence(type, data = {}) {
+                if (!evidence) return null
+                const event = {
+                    seq: evidence.events.length + 1,
+                    type,
+                    at: nowIso(),
+                    data: sanitizeEvidence(data),
+                }
+                evidence.events.push(event)
+                persistEvidence()
+                return event
+            }
+
+            function evidencePayload() {
+                return JSON.stringify(evidence, null, 2)
+            }
+
+            function downloadEvidence() {
+                if (!evidence) return
+                const blob = new Blob([evidencePayload()], { type: 'application/json' })
+                const url = URL.createObjectURL(blob)
+                const link = document.createElement('a')
+                link.href = url
+                link.download = `${evidence.runId}.json`
+                document.body.appendChild(link)
+                link.click()
+                link.remove()
+                URL.revokeObjectURL(url)
+            }
+
+            async function postEvidenceToWorkspace() {
+                const res = await fetch(EVIDENCE_RECEIVER, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: evidencePayload(),
+                })
+                const json = await res.json().catch(() => ({}))
+                if (!res.ok) throw new Error(json.error || `HTTP ${res.status}`)
                 return json
+            }
+
+            async function saveEvidenceToWorkspace(options = {}) {
+                if (!evidence) return null
+                const silent = Boolean(options.silent)
+                recordEvidence('evidence.save_requested', { receiver: EVIDENCE_RECEIVER })
+
+                try {
+                    let result = await postEvidenceToWorkspace()
+                    recordEvidence('evidence.saved_to_workspace', {
+                        path: result.path,
+                        eventCount: evidence.events.length,
+                    })
+                    result = await postEvidenceToWorkspace()
+                    if (!silent) log(`Evidence saved: ${result.path}`, 'success')
+                    return result
+                } catch (e) {
+                    recordEvidence('evidence.save_failed', {
+                        receiver: EVIDENCE_RECEIVER,
+                        error: e.message,
+                    })
+                    if (!silent) {
+                        log(
+                            `Evidence save failed: ${e.message}. Is scripts/sandbox/evidence-server.mjs running?`,
+                            'error'
+                        )
+                    }
+                    return null
+                }
+            }
+
+            async function localJson(path, body, label) {
+                const requestEvent = recordEvidence('local.request', {
+                    label,
+                    path,
+                    body,
+                })
+                const started = performance.now()
+                const res = await fetch(path, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body),
+                })
+                const json = await res.json().catch(() => ({}))
+                recordEvidence('local.response', {
+                    requestSeq: requestEvent?.seq,
+                    label,
+                    path,
+                    status: res.status,
+                    ok: res.ok,
+                    durationMs: Math.round(performance.now() - started),
+                    body: json,
+                })
+
+                if (!res.ok) {
+                    throw new Error(json.error || `HTTP ${res.status}`)
+                }
+
+                return json
+            }
+
+            async function copyEvidence() {
+                if (!evidence) return
+                try {
+                    await navigator.clipboard.writeText(evidencePayload())
+                    log('Evidence copied to clipboard', 'success')
+                } catch (e) {
+                    log(`Copy failed: ${e.message}`, 'error')
+                }
+            }
+
+            function clearEvidence() {
+                evidence = null
+                localStorage.removeItem(EVIDENCE_STORAGE_KEY)
+                updateEvidenceButtons()
+                log('Evidence cleared')
+            }
+
+            // --- Raw REST probe for contract parity ---
+            async function api(method, path, body, label, options = {}) {
+                const cfg = getConfig()
+                const requestEvent = recordEvidence('api.request', {
+                    label,
+                    method,
+                    path,
+                    body,
+                })
+                const started = performance.now()
+                let proxy
+                try {
+                    const res = await fetch('/sandbox-api', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            method,
+                            path,
+                            body,
+                            integrationKey: cfg.integrationKey,
+                            integratorSecret: cfg.integratorSecret,
+                            apiKey: cfg.apiKey,
+                        }),
+                    })
+                    proxy = await res.json()
+                    if (!res.ok) throw new Error(proxy.error || `HTTP ${res.status}`)
+                } catch (e) {
+                    recordEvidence('api.network_error', {
+                        requestSeq: requestEvent?.seq,
+                        label,
+                        method,
+                        path,
+                        durationMs: Math.round(performance.now() - started),
+                        error: e.message,
+                    })
+                    throw new Error(`Sandbox API proxy error: ${e.message}`)
+                }
+                const result = {
+                    label,
+                    method,
+                    path,
+                    status: proxy.status,
+                    ok: proxy.ok,
+                    durationMs: Math.round(performance.now() - started),
+                    headers: proxy.headers || {},
+                    body: proxy.body,
+                }
+                recordEvidence('api.response', {
+                    requestSeq: requestEvent?.seq,
+                    ...result,
+                })
+                if (!proxy.ok) {
+                    const problem =
+                        proxy.body?.detail ||
+                        proxy.body?.title ||
+                        proxy.body?.error ||
+                        `HTTP ${proxy.status}`
+                    const type = proxy.body?.type ? ` (${proxy.body.type})` : ''
+                    if (!options.allowError)
+                        throw new Error(`HTTP ${proxy.status}: ${problem}${type}`)
+                }
+                return options.withMeta ? result : proxy.body
+            }
+
+            async function sdk(action, input, label, options = {}) {
+                const cfg = getConfig()
+                const requestEvent = recordEvidence('sdk.request', {
+                    label,
+                    action,
+                    input,
+                })
+                const started = performance.now()
+                let response
+                try {
+                    const res = await fetch('/sdk-call', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            action,
+                            input,
+                            integrationKey: cfg.integrationKey,
+                            integratorSecret: cfg.integratorSecret,
+                            apiKey: cfg.apiKey,
+                        }),
+                    })
+                    response = await res.json()
+                    if (!res.ok) throw new Error(response.error || `HTTP ${res.status}`)
+                } catch (e) {
+                    recordEvidence('sdk.network_error', {
+                        requestSeq: requestEvent?.seq,
+                        label,
+                        action,
+                        durationMs: Math.round(performance.now() - started),
+                        error: e.message,
+                    })
+                    throw new Error(`SDK proxy error: ${e.message}`)
+                }
+
+                const result = {
+                    label,
+                    action,
+                    ok: Boolean(response.ok),
+                    status: response.ok ? 200 : response.error?.status,
+                    durationMs: Math.round(performance.now() - started),
+                    body: response.ok ? response.body : null,
+                    error: response.ok ? null : response.error,
+                }
+                recordEvidence('sdk.response', {
+                    requestSeq: requestEvent?.seq,
+                    ...result,
+                })
+
+                if (!response.ok && !options.allowError) {
+                    const problem = response.error?.message || `SDK action failed: ${action}`
+                    throw new Error(problem)
+                }
+
+                return options.withMeta ? result : response.body
             }
 
             function getConfig() {
@@ -341,14 +760,167 @@
                 steps[idx].innerHTML = `
     <div class="step-header">
       <span class="step-num ${statusClass}">${status === 'done' ? '✓' : status === 'error' ? '✗' : idx + 1}</span>
-      <span class="step-title">${title}</span>
+      <span class="step-title">${escapeHtml(title)}</span>
     </div>
     <div class="step-body">${content}</div>
   `
             }
 
+            function escapeHtml(value) {
+                return String(value ?? '')
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;')
+            }
+
             function field(label, value) {
-                return `<div class="field"><div class="field-label">${label}</div><div class="field-value">${value}</div></div>`
+                return `<div class="field"><div class="field-label">${escapeHtml(label)}</div><div class="field-value">${escapeHtml(value)}</div></div>`
+            }
+
+            function jsonPre(value) {
+                return `<pre>${escapeHtml(JSON.stringify(value, null, 2))}</pre>`
+            }
+
+            function problemSummary(body) {
+                if (!body || typeof body !== 'object') return ''
+
+                let content =
+                    field('Problem', body.title || body.error || '(none)') +
+                    field('Detail', body.detail || '(none)')
+
+                if (body.requirement) {
+                    content +=
+                        field('Requirement', body.requirement.type || '(none)') +
+                        field('Requirement Status', body.requirement.status || '(none)')
+                }
+
+                if (body.code) content += field('Code', body.code)
+                if (body.type) content += field('Problem Type', body.type)
+                if (Array.isArray(body.errors) && body.errors.length > 0) {
+                    content += body.errors
+                        .map((error, index) =>
+                            field(
+                                `Validation ${index + 1}`,
+                                `${error.field || 'request'}: ${error.code || 'invalid'} — ${
+                                    error.message || '(no message)'
+                                }`
+                            )
+                        )
+                        .join('')
+                }
+                return content
+            }
+
+            function sdkErrorSummary(error) {
+                if (!error) return field('SDK Error', '(none)')
+                return (
+                    field('SDK Error', error.name || '(none)') +
+                    field('Status', error.status || '(none)') +
+                    field('Message', error.message || '(none)') +
+                    problemSummary(error.error)
+                )
+            }
+
+            function createDepositErrorGuidance(error, signalProfile) {
+                const problem = error?.error || {}
+                const code = problem.code || ''
+                const status = error?.status || problem.status
+
+                let content =
+                    field('SDK Method Failed', 'deposit create') +
+                    sdkErrorSummary(error) +
+                    field('ACH Debit Initiated', 'no')
+
+                if (status === 409) {
+                    content += field('Preparation Reusable', 'no — prepare a fresh quote')
+                }
+
+                if (code === 'risk_evaluation_unavailable') {
+                    content += field(
+                        'Meaning',
+                        'Plaid Signal/risk evaluation was unavailable, so Spritz blocked before pulling funds'
+                    )
+                    content += field(
+                        'Likely Cause',
+                        'Signal data may not be ready yet for a newly linked Plaid account, or the funding source is not backed by Signal data'
+                    )
+                    content += field(
+                        'Sandbox Action',
+                        signalProfile?.amountUsd
+                            ? `Use a fresh preparation and rerun the ${signalProfile.label} amount profile`
+                            : 'Use a fresh preparation and a documented Plaid Signal sandbox amount profile'
+                    )
+                } else if (code === 'risk_review_required') {
+                    content += field('Meaning', 'Signal requires review; this is a pre-debit block')
+                } else if (code === 'risk_rejected') {
+                    content += field(
+                        'Meaning',
+                        'Signal rejected or rerouted the debit; this is a pre-debit block'
+                    )
+                }
+
+                content +=
+                    '<div class="button-row">' +
+                    '<button onclick="continueWith(step3_prepareDeposit)">Prepare Fresh Quote</button>' +
+                    '<button class="secondary" onclick="continueWith(waitThenPrepareFreshQuote)">Wait 20s + Prepare Fresh Quote</button>' +
+                    '<button class="secondary" onclick="startPlaidLink()">Link Fresh Bank</button>' +
+                    '<button class="secondary" onclick="saveEvidenceToWorkspace()">Save Evidence to Workspace</button>' +
+                    '</div>'
+
+                return content
+            }
+
+            function linkTokenSuccessSummary(body) {
+                return (
+                    field('Link Token', body?.linkToken ? 'returned' : '(missing)') +
+                    field('Hosted Link URL', body?.hostedLinkUrl ? 'returned' : '(missing)') +
+                    field('Expiration', body?.expiration || '(not returned)')
+                )
+            }
+
+            function selectedSignalProfile() {
+                const key = document.getElementById('signalProfile').value.trim() || 'score60'
+                return SIGNAL_AMOUNT_PROFILES[key] ? key : 'custom'
+            }
+
+            function applySignalProfileAmount() {
+                const key = selectedSignalProfile()
+                const profile = SIGNAL_AMOUNT_PROFILES[key]
+                if (profile?.amountUsd) {
+                    document.getElementById('depositAmount').value = profile.amountUsd
+                    saveFormValues()
+                }
+                return { key, ...profile }
+            }
+
+            function selectedReturnCode() {
+                return document.getElementById('returnSimulationCode').value.trim().toUpperCase()
+            }
+
+            function usd(value) {
+                return value === undefined || value === null || value === ''
+                    ? '(not returned)'
+                    : `$${value}`
+            }
+
+            function ageMs(isoDate) {
+                const created = Date.parse(isoDate || '')
+                if (!Number.isFinite(created)) return null
+                return Date.now() - created
+            }
+
+            function seconds(valueMs) {
+                return Math.ceil(valueMs / 1000)
+            }
+
+            async function continueWith(stepFn) {
+                try {
+                    await stepFn()
+                } catch (e) {
+                    failActiveStep(e)
+                }
             }
 
             // --- Demo flow ---
@@ -362,8 +934,252 @@
                         activeStep,
                         steps[activeStep].querySelector('.step-title')?.textContent || 'Error',
                         'error',
-                        `<span style="color:var(--red)">${error.message}</span>`
+                        `<span style="color:var(--red)">${escapeHtml(error.message)}</span>`
                     )
+                }
+                saveEvidenceToWorkspace({ silent: true })
+            }
+
+            function resetRunState() {
+                document.getElementById('steps').innerHTML = ''
+                document.getElementById('log').innerHTML = ''
+                steps = []
+                activeStep = 0
+            }
+
+            function getIntegratorConfig() {
+                const cfg = getConfig()
+                if (!cfg.integrationKey || !cfg.integratorSecret) {
+                    throw new Error('Fill in integration key and integrator secret')
+                }
+                return cfg
+            }
+
+            function sleep(ms) {
+                return new Promise((resolve) => setTimeout(resolve, ms))
+            }
+
+            function ensureEvidenceRun() {
+                if (!evidence) initEvidence()
+            }
+
+            async function createFreshSandboxUser({ reset = true } = {}) {
+                const cfg = getIntegratorConfig()
+                if (reset) {
+                    resetRunState()
+                    state = {}
+                    initEvidence()
+                } else {
+                    ensureEvidenceRun()
+                }
+
+                activeStep = 0
+                renderStep(0, 'Create Fresh Sandbox User', 'active', 'Creating user...')
+                const user = await localJson(
+                    '/sandbox-user/create',
+                    {
+                        integrationKey: cfg.integrationKey,
+                        fresh: true,
+                    },
+                    'sandbox_user.create_fresh'
+                )
+                state.generatedUser = user
+                document.getElementById('sandboxUserEmail').value = user.email
+                document.getElementById('apiKey').value = user.apiKey
+                saveFormValues()
+                renderStep(
+                    0,
+                    'Create Fresh Sandbox User',
+                    'done',
+                    field('User ID', user.userId) +
+                        field('Email', user.email) +
+                        field('API Key', 'generated and filled')
+                )
+                log(`Generated fresh sandbox user: ${user.email}`, 'success')
+                return user
+            }
+
+            async function generateFreshUser() {
+                try {
+                    await createFreshSandboxUser()
+                    await saveEvidenceToWorkspace({ silent: true })
+                } catch (e) {
+                    failActiveStep(e)
+                }
+            }
+
+            async function bypassCurrentUserKyc() {
+                try {
+                    const cfg = getIntegratorConfig()
+                    if (!cfg.apiKey) throw new Error('Generate or enter an API key first')
+                    ensureEvidenceRun()
+
+                    activeStep = 1
+                    renderStep(1, 'Bypass KYC', 'active', 'Bypassing current user to US...')
+                    await sdk('sandbox.bypassKyc', { country: 'US' }, 'sandbox.bypass_kyc_us')
+                    renderStep(1, 'Bypass KYC', 'done', field('Country', 'US'))
+                    log('Current user KYC bypassed to US', 'success')
+                    await saveEvidenceToWorkspace({ silent: true })
+                } catch (e) {
+                    failActiveStep(e)
+                }
+            }
+
+            async function runKycGateQc() {
+                try {
+                    const user = await createFreshSandboxUser()
+
+                    await probeLinkTokenGate({
+                        step: 1,
+                        title: 'Pre-KYC Link Token Gate',
+                        expectedOk: false,
+                    })
+
+                    activeStep = 2
+                    renderStep(2, 'Bypass KYC', 'active', 'Bypassing KYC to US through SDK...')
+                    await sdk('sandbox.bypassKyc', { country: 'US' }, 'sandbox.bypass_kyc_us')
+                    renderStep(
+                        2,
+                        'Bypass KYC',
+                        'done',
+                        field('SDK Method', 'sandbox.bypassKyc') + field('Country', 'US')
+                    )
+                    log('KYC bypassed to US', 'success')
+
+                    await probeLinkTokenGate({
+                        step: 3,
+                        title: 'Post-KYC Link Token Gate',
+                        expectedOk: true,
+                        attempts: 5,
+                    })
+
+                    renderStep(
+                        4,
+                        'SDK KYC Gate QC Complete',
+                        'done',
+                        '<p style="color:var(--green)">SDK blocked the unverified user, then allowed the US-verified user.</p>' +
+                            field('User ID', user.userId) +
+                            field('Email', user.email) +
+                            '<div class="button-row"><button onclick="saveEvidenceToWorkspace()">Save Evidence to Workspace</button></div>'
+                    )
+                    recordEvidence('kyc_gate_qc.completed', {
+                        userId: user.userId,
+                        email: user.email,
+                    })
+                    await saveEvidenceToWorkspace({ silent: true })
+                } catch (e) {
+                    failActiveStep(e)
+                }
+            }
+
+            async function probeLinkTokenGate({ step, title, expectedOk, attempts = 1 }) {
+                activeStep = step
+                let lastResult = null
+
+                for (let attempt = 1; attempt <= attempts; attempt += 1) {
+                    renderStep(
+                        step,
+                        title,
+                        'active',
+                        `SDK bankAccount.createLinkToken() (attempt ${attempt}/${attempts})`
+                    )
+                    log(`SDK bankAccount.createLinkToken() (${title})`)
+                    lastResult = await sdk(
+                        'bankAccount.createLinkToken',
+                        undefined,
+                        expectedOk
+                            ? 'sdk.bank_accounts.link_token.post_kyc_probe'
+                            : 'sdk.bank_accounts.link_token.pre_kyc_probe',
+                        { allowError: true, withMeta: true }
+                    )
+
+                    const matchedExpectation = expectedOk
+                        ? lastResult.ok
+                        : !lastResult.ok && lastResult.status === 403
+
+                    recordEvidence('kyc_gate.probe', {
+                        title,
+                        expectedOk,
+                        attempt,
+                        matchedExpectation,
+                        status: lastResult.status,
+                        ok: lastResult.ok,
+                        body: lastResult.body,
+                        error: lastResult.error,
+                    })
+
+                    if (matchedExpectation) {
+                        const restParity = await probeRestLinkTokenGate({
+                            title,
+                            expectedOk,
+                        })
+                        const content = expectedOk
+                            ? field('Expected', 'success after US KYC') +
+                              field('Actual Status', lastResult.status) +
+                              field('Result', 'link token created') +
+                              linkTokenSuccessSummary(lastResult.body) +
+                              field('REST Parity', restParity.matched ? 'matched' : 'mismatch')
+                            : field('Expected', '403 before KYC') +
+                              field('Actual Status', lastResult.status) +
+                              field('Result', 'blocked until US verification') +
+                              sdkErrorSummary(lastResult.error) +
+                              field('REST Parity', restParity.matched ? 'matched' : 'mismatch')
+
+                        if (!restParity.matched) {
+                            throw new Error(
+                                `${title} REST parity failed: expected ${
+                                    expectedOk ? 'success' : '403'
+                                }, got ${restParity.status ?? 'no response'}`
+                            )
+                        }
+
+                        renderStep(step, title, 'done', content)
+                        log(`${title}: passed`, 'success')
+                        return lastResult
+                    }
+
+                    if (expectedOk && attempt < attempts) await sleep(1000)
+                }
+
+                renderStep(
+                    step,
+                    title,
+                    'error',
+                    field('Expected', expectedOk ? 'success' : '403 before KYC') +
+                        field('Actual Status', lastResult?.status ?? '(none)') +
+                        problemSummary(lastResult?.body) +
+                        sdkErrorSummary(lastResult?.error) +
+                        '<p style="margin-top:0.5rem;font-size:0.7rem">Raw response is captured in the evidence file.</p>'
+                )
+                throw new Error(
+                    `${title} failed: expected ${expectedOk ? 'success' : '403'}, got ${
+                        lastResult?.status ?? 'no response'
+                    }`
+                )
+            }
+
+            async function probeRestLinkTokenGate({ title, expectedOk }) {
+                const result = await api(
+                    'POST',
+                    '/v1/bank-accounts/link-token',
+                    undefined,
+                    expectedOk
+                        ? 'api.bank_accounts.link_token.post_kyc_parity'
+                        : 'api.bank_accounts.link_token.pre_kyc_parity',
+                    { allowError: true, withMeta: true }
+                )
+                const matched = expectedOk ? result.ok : !result.ok && result.status === 403
+                recordEvidence('kyc_gate.rest_parity', {
+                    title,
+                    expectedOk,
+                    matched,
+                    status: result.status,
+                    ok: result.ok,
+                    body: result.body,
+                })
+                return {
+                    matched,
+                    status: result.status,
                 }
             }
 
@@ -379,10 +1195,8 @@
                     return
                 }
                 state = { walletAddress: wallet }
-                document.getElementById('steps').innerHTML = ''
-                document.getElementById('log').innerHTML = ''
-                steps = []
-                activeStep = 0
+                resetRunState()
+                initEvidence()
 
                 try {
                     await step1_checkFundingSources()
@@ -392,10 +1206,15 @@
             }
 
             async function step1_checkFundingSources() {
+                activeStep = 0
                 renderStep(0, 'Check Funding Sources', 'active', 'Fetching...')
-                log('GET /v1/funding-sources/')
+                log('SDK fundingSource.list()')
 
-                const sources = await api('GET', '/v1/funding-sources/')
+                const sources = await sdk(
+                    'fundingSource.list',
+                    undefined,
+                    'sdk.funding_sources.list'
+                )
                 state.fundingSources = sources
 
                 if (sources.length === 0) {
@@ -413,6 +1232,7 @@
                 const active = sources.find((s) => s.status === 'active')
                 if (active) {
                     state.selectedSource = active
+                    recordEvidence('funding_source.selected', active)
                     renderStep(
                         0,
                         'Funding Source',
@@ -426,7 +1246,7 @@
                             field('Status', active.status)
                     )
                     log(`Using funding source: ${active.id}`, 'success')
-                    await step2_createDeposit()
+                    await step2_getDepositLimits()
                 } else {
                     const first = sources[0]
                     renderStep(
@@ -436,45 +1256,94 @@
                         field('ID', first.id) +
                             field('Status', `${first.status} — waiting for activation`) +
                             '<p style="margin-top:0.5rem">Funding source is not yet active. This may take a moment after Plaid linking.</p>' +
-                            '<button onclick="step1_checkFundingSources()">Refresh</button>'
+                            '<button onclick="continueWith(step1_checkFundingSources)">Refresh</button>'
                     )
                     log(`Funding source ${first.id} status: ${first.status}`)
                 }
             }
 
             async function startPlaidLink() {
+                activeStep = 0
                 renderStep(0, 'Link Bank Account', 'active', 'Creating Plaid link token...')
-                log('POST /v1/bank-accounts/link-token')
+                log('SDK bankAccount.createLinkToken()')
 
-                const { linkToken } = await api('POST', '/v1/bank-accounts/link-token')
+                const linkTokenResult = await sdk(
+                    'bankAccount.createLinkToken',
+                    undefined,
+                    'sdk.bank_accounts.link_token',
+                    { allowError: true, withMeta: true }
+                )
+                if (!linkTokenResult.ok) {
+                    renderStep(
+                        0,
+                        'Link Bank Account',
+                        'error',
+                        field('Status', linkTokenResult.status) +
+                            sdkErrorSummary(linkTokenResult.error) +
+                            '<p style="margin-top:0.5rem">Run the KYC gate check or use a US-verified sandbox user before opening Plaid Link.</p>' +
+                            '<div class="button-row">' +
+                            '<button onclick="bypassCurrentUserKyc()">Bypass KYC (US)</button>' +
+                            '<button class="secondary" onclick="runKycGateQc()">Full SDK KYC Gate QC</button>' +
+                            '<button class="secondary" onclick="startPlaidLink()">Retry</button>' +
+                            '</div>'
+                    )
+                    log(`Link token blocked: HTTP ${linkTokenResult.status}`, 'error')
+                    recordEvidence('plaid.link_token_blocked', {
+                        status: linkTokenResult.status,
+                        error: linkTokenResult.error,
+                    })
+                    await saveEvidenceToWorkspace({ silent: true })
+                    return
+                }
+
+                const { linkToken } = linkTokenResult.body
                 log(`Link token received`, 'success')
 
                 const handler = Plaid.create({
                     token: linkToken,
                     onSuccess: async (publicToken, metadata) => {
-                        log(`Plaid success — exchanging token`)
-                        renderStep(0, 'Link Bank Account', 'active', 'Completing link...')
+                        try {
+                            recordEvidence('plaid.success', {
+                                metadata,
+                                selectedAccountIds: metadata.accounts.map((a) => a.id),
+                            })
+                            log(`Plaid success — exchanging token`)
+                            renderStep(0, 'Link Bank Account', 'active', 'Completing link...')
 
-                        const accountIds = metadata.accounts.map((a) => a.id)
-                        await api('POST', '/v1/bank-accounts/link-complete', {
-                            publicToken,
-                            accountIds,
-                            institutionId: metadata.institution?.institution_id,
-                            institutionName: metadata.institution?.name,
-                        })
+                            const accountIds = metadata.accounts.map((a) => a.id)
+                            await sdk(
+                                'bankAccount.completeLinking',
+                                {
+                                    publicToken,
+                                    accountIds,
+                                    institutionId: metadata.institution?.institution_id,
+                                    institutionName: metadata.institution?.name,
+                                },
+                                'sdk.bank_accounts.link_complete'
+                            )
 
-                        log('Bank account linked', 'success')
-                        renderStep(0, 'Link Bank Account', 'done', 'Bank account linked via Plaid.')
-                        await step1_checkFundingSources()
+                            log('Bank account linked', 'success')
+                            renderStep(
+                                0,
+                                'Link Bank Account',
+                                'done',
+                                'Bank account linked via Plaid.'
+                            )
+                            await step1_checkFundingSources()
+                        } catch (e) {
+                            failActiveStep(e)
+                        }
                     },
                     onExit: (err) => {
+                        recordEvidence('plaid.exit', { error: err })
                         if (err) {
-                            log(`Plaid error: ${err.display_message || err.error_code}`, 'error')
+                            const message = err.display_message || err.error_code
+                            log(`Plaid error: ${message}`, 'error')
                             renderStep(
                                 0,
                                 'Link Bank Account',
                                 'error',
-                                `Plaid error: ${err.display_message || err.error_code}<br><button onclick="startPlaidLink()">Retry</button>`
+                                `Plaid error: ${escapeHtml(message)}<br><button onclick="startPlaidLink()">Retry</button>`
                             )
                         } else {
                             log('Plaid link closed')
@@ -490,19 +1359,84 @@
                 handler.open()
             }
 
-            async function step2_createDeposit() {
+            async function step2_getDepositLimits() {
                 activeStep = 1
+                const sourceId = state.selectedSource.id
+
+                renderStep(1, 'Deposit Limits', 'active', 'Fetching current ACH limits...')
+                log('SDK fundingSource.getDepositLimits()')
+
+                const limits = await sdk(
+                    'fundingSource.getDepositLimits',
+                    { fundingSourceId: sourceId },
+                    'sdk.funding_sources.deposit_limits'
+                )
+                state.depositLimits = limits
+
+                const amount = document.getElementById('depositAmount').value.trim() || '1.00'
+                const requested = Number(amount)
+                const warnings = []
+                if (Number.isFinite(requested)) {
+                    if (requested < Number(limits.minimumDepositAmountUsd)) {
+                        warnings.push(`below minimum ${usd(limits.minimumDepositAmountUsd)}`)
+                    }
+                    if (requested > Number(limits.transactionLimitUsd)) {
+                        warnings.push(`above transaction limit ${usd(limits.transactionLimitUsd)}`)
+                    }
+                    if (requested > Number(limits.dailyRemainingUsd)) {
+                        warnings.push(`above daily remaining ${usd(limits.dailyRemainingUsd)}`)
+                    }
+                    if (requested > Number(limits.monthlyRemainingUsd)) {
+                        warnings.push(`above monthly remaining ${usd(limits.monthlyRemainingUsd)}`)
+                    }
+                }
+                if (limits.unsettledDepositRemaining <= 0) {
+                    warnings.push('no unsettled deposit capacity remaining')
+                }
+
+                renderStep(
+                    1,
+                    'Deposit Limits',
+                    'done',
+                    field('SDK Method', 'fundingSource.getDepositLimits') +
+                        field('Funding Source', sourceId) +
+                        field('Minimum Deposit', usd(limits.minimumDepositAmountUsd)) +
+                        field('Transaction Limit', usd(limits.transactionLimitUsd)) +
+                        field(
+                            'Daily Remaining',
+                            `${usd(limits.dailyRemainingUsd)} / ${usd(limits.dailyLimitUsd)}`
+                        ) +
+                        field(
+                            'Monthly Remaining',
+                            `${usd(limits.monthlyRemainingUsd)} / ${usd(limits.monthlyLimitUsd)}`
+                        ) +
+                        field(
+                            'Unsettled Remaining',
+                            `${limits.unsettledDepositRemaining} / ${limits.unsettledDepositLimit}`
+                        ) +
+                        field(
+                            'Requested Amount Check',
+                            warnings.length ? warnings.join('; ') : 'ok'
+                        )
+                )
+                log('Deposit limits fetched', 'success')
+                await step3_prepareDeposit()
+            }
+
+            async function step3_prepareDeposit() {
+                activeStep = 2
+                const signalProfile = applySignalProfileAmount()
                 const amount = document.getElementById('depositAmount').value.trim() || '1.00'
                 const subsidyPct = document.getElementById('feeSubsidyPct').value.trim()
                 const subsidyMax = document.getElementById('feeSubsidyMax').value.trim()
 
                 renderStep(
-                    1,
+                    2,
                     'Prepare Deposit',
                     'active',
                     `Preparing deposit quote ($${amount})...`
                 )
-                log('POST /v1/deposits/direct/prepare')
+                log('SDK deposit.prepare()')
 
                 const body = {
                     sourceId: state.selectedSource.id,
@@ -518,10 +1452,16 @@
                     if (subsidyMax) body.feeSubsidy.maxAmountUsd = subsidyMax
                 }
 
-                const prep = await api('POST', '/v1/deposits/direct/prepare', body)
+                const prep = await sdk('deposit.prepare', body, 'sdk.deposits.direct.prepare')
                 state.depositPrep = prep
                 const s = prep.summary
                 log(`Quote: $${s.totalDebitAmountUsd} debit → ${s.expectedAssetAmount} USDC`)
+                recordEvidence('authorization.presented', {
+                    preparationId: prep.preparationId,
+                    message: prep.message,
+                    summary: prep.summary,
+                    signalProfile,
+                })
 
                 let feeDetail = `$${s.userFeeUsd} (${s.feeRateBps} bps)`
                 let subsidyDetail = ''
@@ -538,29 +1478,165 @@
                 }
 
                 renderStep(
-                    1,
-                    'Prepare Deposit',
+                    2,
+                    'Review Authorization',
                     'active',
                     field('Requested', `$${s.requestedAmountUsd}`) +
+                        field(
+                            'Signal Amount Profile',
+                            `${signalProfile.label} (${signalProfile.expected})`
+                        ) +
                         field('User Fee', feeDetail) +
                         subsidyDetail +
                         field('Total Debit', `$${s.totalDebitAmountUsd}`) +
                         field('Expected USDC', s.expectedAssetAmount) +
                         field('Destination', s.destinationAddress) +
                         '<p style="margin-top:0.5rem;font-size:0.7rem">Authorization message:</p>' +
-                        `<pre>${prep.message}</pre>` +
-                        '<p style="margin-top:0.5rem;font-size:0.7rem">Submitting deposit...</p>'
+                        `<pre>${escapeHtml(prep.message)}</pre>` +
+                        '<div class="button-row"><button onclick="continueWith(confirmDeposit)">Confirm Deposit</button></div>'
                 )
+            }
 
-                log('POST /v1/deposits/direct')
-                const deposit = await api('POST', '/v1/deposits/direct', {
-                    preparationId: prep.preparationId,
+            async function waitForSignalDataReadiness() {
+                if (!state.selectedSource?.createdAt) return
+
+                const sourceAgeMs = ageMs(state.selectedSource.createdAt)
+                if (sourceAgeMs === null || sourceAgeMs >= SIGNAL_DATA_READY_DELAY_MS) return
+
+                const waitMs = SIGNAL_DATA_READY_DELAY_MS - sourceAgeMs
+                activeStep = 3
+                recordEvidence('signal.readiness_wait_started', {
+                    fundingSourceId: state.selectedSource.id,
+                    fundingSourceCreatedAt: state.selectedSource.createdAt,
+                    sourceAgeMs,
+                    waitMs,
                 })
+                renderStep(
+                    3,
+                    'Signal Data Readiness',
+                    'active',
+                    field('Funding Source Age', `${seconds(sourceAgeMs)}s`) +
+                        field('Waiting Before Create', `${seconds(waitMs)}s`) +
+                        field(
+                            'Reason',
+                            'Plaid Signal sandbox data may take a short time after Link'
+                        )
+                )
+                log(`Waiting ${seconds(waitMs)}s for Plaid Signal data readiness`)
+                await sleep(waitMs)
+                recordEvidence('signal.readiness_wait_completed', {
+                    fundingSourceId: state.selectedSource.id,
+                    waitedMs: waitMs,
+                })
+            }
+
+            async function waitThenPrepareFreshQuote() {
+                activeStep = 3
+                renderStep(
+                    3,
+                    'Signal Data Readiness',
+                    'active',
+                    field('Waiting Before New Quote', `${seconds(SIGNAL_DATA_READY_DELAY_MS)}s`) +
+                        field('Reason', 'Retrying after Plaid Signal data readiness window')
+                )
+                log(`Waiting ${seconds(SIGNAL_DATA_READY_DELAY_MS)}s before fresh quote`)
+                recordEvidence('signal.manual_wait_started', {
+                    waitMs: SIGNAL_DATA_READY_DELAY_MS,
+                    fundingSourceId: state.selectedSource?.id || null,
+                })
+                await sleep(SIGNAL_DATA_READY_DELAY_MS)
+                recordEvidence('signal.manual_wait_completed', {
+                    fundingSourceId: state.selectedSource?.id || null,
+                })
+                await step3_prepareDeposit()
+            }
+
+            async function confirmDeposit() {
+                activeStep = 3
+                if (!state.depositPrep) throw new Error('Prepare a deposit before confirming')
+
+                const signalProfile = applySignalProfileAmount()
+                const returnCode = selectedReturnCode()
+                const createPath = returnCode
+                    ? '/v1/sandbox/deposits/direct'
+                    : '/v1/deposits/direct'
+                const createBody = {
+                    preparationId: state.depositPrep.preparationId,
+                    clientContext: {
+                        userAgent: navigator.userAgent,
+                        platform: navigator.platform,
+                    },
+                }
+                if (returnCode) createBody.returnSimulation = { code: returnCode }
+
+                renderStep(
+                    2,
+                    'Authorization Reviewed',
+                    'done',
+                    field('Preparation', state.depositPrep.preparationId) +
+                        field(
+                            'Signal Amount Profile',
+                            `${signalProfile.label} (${signalProfile.expected})`
+                        ) +
+                        field(
+                            'Amount Sent to Signal',
+                            `$${document.getElementById('depositAmount').value.trim()}`
+                        ) +
+                        field('Return Simulation', returnCode || '(none)')
+                )
+                renderStep(3, 'Create Deposit', 'active', 'Submitting confirmed deposit...')
+                recordEvidence('user.confirmed_deposit', {
+                    preparationId: state.depositPrep.preparationId,
+                    signalProfile,
+                    signalAmountUsd: document.getElementById('depositAmount').value.trim(),
+                    returnCode,
+                    createPath,
+                })
+                const createAction = returnCode
+                    ? 'sandbox.createDepositWithReturn'
+                    : 'deposit.create'
+                log(`SDK ${createAction}()`)
+
+                await waitForSignalDataReadiness()
+                renderStep(3, 'Create Deposit', 'active', 'Submitting confirmed deposit...')
+
+                const createResult = await sdk(
+                    createAction,
+                    createBody,
+                    createPath.includes('/sandbox/')
+                        ? 'sdk.sandbox.deposits.direct.create'
+                        : 'sdk.deposits.direct.create',
+                    { allowError: true, withMeta: true }
+                )
+                if (!createResult.ok) {
+                    recordEvidence('deposit.create_blocked', {
+                        createAction,
+                        signalProfile,
+                        signalAmountUsd: document.getElementById('depositAmount').value.trim(),
+                        returnCode,
+                        status: createResult.status,
+                        error: createResult.error,
+                    })
+                    renderStep(
+                        3,
+                        'Create Deposit Blocked',
+                        'error',
+                        createDepositErrorGuidance(createResult.error, signalProfile)
+                    )
+                    log(
+                        `Create blocked: ${createResult.error?.message || 'unknown error'}`,
+                        'error'
+                    )
+                    await saveEvidenceToWorkspace({ silent: true })
+                    return
+                }
+
+                const deposit = createResult.body
                 state.deposit = deposit
                 log(`Deposit created: ${deposit.id} [${deposit.status}]`, 'success')
 
                 renderStep(
-                    1,
+                    3,
                     'Deposit Created',
                     'done',
                     field('ID', deposit.id) +
@@ -573,16 +1649,141 @@
                         field('To', deposit.address)
                 )
 
+                await step5_fetchOnRamp()
+            }
+
+            async function step5_fetchOnRamp() {
+                activeStep = 4
+                if (!state.deposit) throw new Error('Create a deposit before polling on-ramps')
+
+                renderStep(4, 'On-Ramp Polling', 'active', 'Fetching recent on-ramps...')
+                log('SDK onrampPayment.list()')
+                const onRamps = await sdk(
+                    'onrampPayment.list',
+                    {
+                        query: {
+                            network: 'solana',
+                            token: 'USDC',
+                            address: state.walletAddress,
+                            limit: 10,
+                            sort: 'desc',
+                        },
+                    },
+                    'sdk.onramp_payment.list'
+                )
+                state.onRamps = onRamps
+
+                const rows = onRamps.data || []
+                const matched =
+                    rows.find((row) => row.id === state.deposit.bridgeOnRampId) ||
+                    rows.find((row) => row.output?.address === state.walletAddress) ||
+                    null
+                let detail = null
+                if (state.deposit.bridgeOnRampId) {
+                    log('SDK onrampPayment.get()')
+                    detail = await sdk(
+                        'onrampPayment.get',
+                        { onRampId: state.deposit.bridgeOnRampId },
+                        'sdk.onramp_payment.get'
+                    )
+                    state.onRampDetail = detail
+                }
+
+                const status = matched || detail ? 'done' : 'active'
                 renderStep(
-                    2,
+                    4,
+                    'On-Ramp Polling',
+                    status,
+                    field('List Count', rows.length) +
+                        field(
+                            'Deposit bridgeOnRampId',
+                            state.deposit.bridgeOnRampId || '(not set)'
+                        ) +
+                        field('Matched On-Ramp', (detail || matched)?.id || '(not found yet)') +
+                        field('Matched Status', (detail || matched)?.status || '(not found yet)') +
+                        '<div class="button-row"><button class="secondary" onclick="continueWith(step5_fetchOnRamp)">Refresh On-Ramp</button></div>' +
+                        (detail || matched ? jsonPre(detail || matched) : '')
+                )
+
+                renderStep(
+                    5,
                     'Done',
                     'done',
-                    '<p style="color:var(--green)">ACH onramp flow complete.</p>' +
+                    '<p style="color:var(--green)">ACH onramp flow captured.</p>' +
                         field('Funding Source', state.selectedSource.id) +
-                        field('Deposit', deposit.id) +
-                        field('Wallet', state.walletAddress)
+                        field('Deposit', state.deposit.id) +
+                        field('Wallet', state.walletAddress) +
+                        '<div class="button-row">' +
+                        '<button onclick="saveEvidenceToWorkspace()">Save Evidence to Workspace</button>' +
+                        '<button class="secondary" onclick="downloadEvidence()">Download Evidence</button>' +
+                        '<button class="secondary" onclick="continueWith(fetchAchReturns)">Fetch ACH Returns</button>' +
+                        '</div>'
                 )
+                recordEvidence('run.ready_for_review', {
+                    depositId: state.deposit.id,
+                    bridgeOnRampId: state.deposit.bridgeOnRampId,
+                    onRampMatched: Boolean(detail || matched),
+                })
+                await saveEvidenceToWorkspace({ silent: true })
             }
+
+            async function fetchAchReturns() {
+                activeStep = 6
+                if (!state.deposit) throw new Error('Create a deposit before fetching returns')
+
+                renderStep(6, 'ACH Returns', 'active', 'Fetching ACH debit returns...')
+                log('SDK achDebitReturn.list()')
+                const returns = await sdk(
+                    'achDebitReturn.list',
+                    {
+                        query: {
+                            limit: 20,
+                            search: state.deposit.id,
+                        },
+                    },
+                    'sdk.ach_debit_return.list'
+                )
+                state.achReturns = returns
+
+                const rows = returns.data || []
+                const matched = rows.find((row) => row.depositId === state.deposit.id) || null
+                let detail = null
+                if (matched) {
+                    log('SDK achDebitReturn.get()')
+                    detail = await sdk(
+                        'achDebitReturn.get',
+                        { returnId: matched.id },
+                        'sdk.ach_debit_return.get'
+                    )
+                    state.achReturnDetail = detail
+                }
+
+                renderStep(
+                    6,
+                    'ACH Returns',
+                    matched ? 'done' : 'active',
+                    field('Return Count', rows.length) +
+                        field('Matched Return', matched?.id || '(not found yet)') +
+                        field('Return Code', (detail || matched)?.returnCode || '(not returned)') +
+                        field(
+                            'Return Reason',
+                            (detail || matched)?.returnReason || '(not returned)'
+                        ) +
+                        '<div class="button-row"><button class="secondary" onclick="continueWith(fetchAchReturns)">Refresh Returns</button></div>' +
+                        (detail || matched ? jsonPre(detail || matched) : jsonPre(returns))
+                )
+                recordEvidence('ach_returns.polled', {
+                    depositId: state.deposit.id,
+                    matchedReturnId: matched?.id || null,
+                    returnCode: (detail || matched)?.returnCode || null,
+                })
+                await saveEvidenceToWorkspace({ silent: true })
+            }
+
+            restoreFormValues()
+            bindFormPersistence()
+            loadEvidence()
+            document.getElementById('appVersionLabel').textContent = APP_VERSION
         </script>
     </body>
 </html>

--- a/scripts/sandbox/ach-onramp.html
+++ b/scripts/sandbox/ach-onramp.html
@@ -278,7 +278,7 @@
             <p class="evidence-note">
                 Evidence export redacts credentials, HMAC signatures, Plaid public tokens, and link
                 tokens. Workspace saves go to <code>qc/evidence/</code> when the local receiver is
-                running. Sandbox form values are saved in this browser.
+                running. Non-sensitive sandbox form values are saved in this browser.
             </p>
         </div>
 
@@ -306,7 +306,6 @@
                     expected: 'no hardcoded Signal score',
                 },
             }
-            const EVIDENCE_STORAGE_KEY = 'spritz-ach-onramp-evidence'
             const FORM_STORAGE_KEY = 'spritz-ach-onramp-form'
             const EVIDENCE_RECEIVER = `${window.location.origin}/evidence`
             const FORM_FIELD_IDS = [
@@ -321,6 +320,9 @@
                 'signalProfile',
                 'returnSimulationCode',
             ]
+            const PERSISTED_FORM_FIELD_IDS = FORM_FIELD_IDS.filter(
+                (id) => !['integrationKey', 'integratorSecret', 'apiKey'].includes(id)
+            )
 
             // --- Evidence capture ---
             let evidence = null
@@ -374,7 +376,7 @@
 
             function collectFormValues() {
                 return Object.fromEntries(
-                    FORM_FIELD_IDS.map((id) => [id, getFormField(id)?.value ?? ''])
+                    PERSISTED_FORM_FIELD_IDS.map((id) => [id, getFormField(id)?.value ?? ''])
                 )
             }
 
@@ -388,7 +390,7 @@
 
                 try {
                     const values = JSON.parse(raw)
-                    for (const id of FORM_FIELD_IDS) {
+                    for (const id of PERSISTED_FORM_FIELD_IDS) {
                         const field = getFormField(id)
                         if (field && typeof values[id] === 'string') field.value = values[id]
                     }
@@ -464,19 +466,7 @@
 
             function persistEvidence() {
                 if (!evidence) return
-                localStorage.setItem(EVIDENCE_STORAGE_KEY, JSON.stringify(evidence))
                 updateEvidenceButtons()
-            }
-
-            function loadEvidence() {
-                const raw = localStorage.getItem(EVIDENCE_STORAGE_KEY)
-                if (!raw) return
-                try {
-                    evidence = JSON.parse(raw)
-                    updateEvidenceButtons()
-                } catch {
-                    localStorage.removeItem(EVIDENCE_STORAGE_KEY)
-                }
             }
 
             function updateEvidenceButtons() {
@@ -598,7 +588,6 @@
 
             function clearEvidence() {
                 evidence = null
-                localStorage.removeItem(EVIDENCE_STORAGE_KEY)
                 updateEvidenceButtons()
                 log('Evidence cleared')
             }
@@ -1782,7 +1771,6 @@
 
             restoreFormValues()
             bindFormPersistence()
-            loadEvidence()
             document.getElementById('appVersionLabel').textContent = APP_VERSION
         </script>
     </body>

--- a/scripts/sandbox/evidence-server.mjs
+++ b/scripts/sandbox/evidence-server.mjs
@@ -5,7 +5,7 @@ import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { dirname, extname, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-const host = process.env.EVIDENCE_HOST || '0.0.0.0'
+const host = process.env.EVIDENCE_HOST || '127.0.0.1'
 const port = Number(process.env.PORT || process.env.EVIDENCE_PORT || 3001)
 const staticRoot = dirname(fileURLToPath(import.meta.url))
 const outputDir = resolve(process.cwd(), process.env.EVIDENCE_DIR || 'qc/evidence')
@@ -77,6 +77,7 @@ function safeFileName(value) {
     const base = String(value || `ach-qc-${new Date().toISOString()}`)
         .replace(/[:]/g, '-')
         .replace(/[^a-zA-Z0-9_.-]/g, '_')
+        .replace(/\.json$/i, '')
         .slice(0, 160)
     return `${base || 'ach-qc-evidence'}.json`
 }

--- a/scripts/sandbox/evidence-server.mjs
+++ b/scripts/sandbox/evidence-server.mjs
@@ -1,0 +1,489 @@
+#!/usr/bin/env node
+import { createServer } from 'node:http'
+import { createHash, createHmac } from 'node:crypto'
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { dirname, extname, resolve, sep } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const host = process.env.EVIDENCE_HOST || '0.0.0.0'
+const port = Number(process.env.PORT || process.env.EVIDENCE_PORT || 3001)
+const staticRoot = dirname(fileURLToPath(import.meta.url))
+const outputDir = resolve(process.cwd(), process.env.EVIDENCE_DIR || 'qc/evidence')
+const maxBodyBytes = 5 * 1024 * 1024
+const legacySandboxBaseUrl = 'https://api-staging.spritz.finance'
+const sandboxRestBaseUrl = 'https://sandbox.spritz.finance'
+const sdkModulePath = resolve(staticRoot, '../../dist/spritz-api-client.mjs')
+let sdkModulePromise = null
+
+function sendJson(res, status, body) {
+    res.writeHead(status, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'content-type',
+        'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+        'Content-Type': 'application/json',
+    })
+    res.end(JSON.stringify(body))
+}
+
+function contentType(filePath) {
+    switch (extname(filePath)) {
+        case '.html':
+            return 'text/html; charset=utf-8'
+        case '.js':
+        case '.mjs':
+            return 'text/javascript; charset=utf-8'
+        case '.css':
+            return 'text/css; charset=utf-8'
+        case '.json':
+            return 'application/json; charset=utf-8'
+        default:
+            return 'application/octet-stream'
+    }
+}
+
+async function sendStatic(req, res, pathname) {
+    const relativePath = pathname === '/' ? '/ach-onramp.html' : pathname
+    const filePath = resolve(staticRoot, `.${relativePath}`)
+
+    if (filePath !== staticRoot && !filePath.startsWith(`${staticRoot}${sep}`)) {
+        sendJson(res, 403, { ok: false, error: 'Forbidden' })
+        return
+    }
+
+    try {
+        const fileStat = await stat(filePath)
+        if (!fileStat.isFile()) {
+            sendJson(res, 404, { ok: false, error: 'Not found' })
+            return
+        }
+
+        res.writeHead(200, {
+            'Cache-Control': 'no-store',
+            'Content-Length': fileStat.size,
+            'Content-Type': contentType(filePath),
+        })
+
+        if (req.method !== 'HEAD') {
+            res.end(await readFile(filePath))
+        } else {
+            res.end()
+        }
+    } catch {
+        sendJson(res, 404, { ok: false, error: 'Not found' })
+    }
+}
+
+function safeFileName(value) {
+    const base = String(value || `ach-qc-${new Date().toISOString()}`)
+        .replace(/[:]/g, '-')
+        .replace(/[^a-zA-Z0-9_.-]/g, '_')
+        .slice(0, 160)
+    return `${base || 'ach-qc-evidence'}.json`
+}
+
+function assertString(value, name) {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new Error(`${name} is required`)
+    }
+    return value.trim()
+}
+
+function assertObject(value, name) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${name} is required`)
+    }
+    return value
+}
+
+function optionalQuery(input) {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) return undefined
+    return 'query' in input ? input.query : input
+}
+
+async function readBody(req) {
+    const chunks = []
+    let size = 0
+
+    for await (const chunk of req) {
+        size += chunk.length
+        if (size > maxBodyBytes) throw new Error('Evidence payload is too large')
+        chunks.push(chunk)
+    }
+
+    return Buffer.concat(chunks).toString('utf8')
+}
+
+async function readJsonBody(req) {
+    const body = await readBody(req)
+    if (!body) return {}
+    return JSON.parse(body)
+}
+
+function sha256Hex(data) {
+    return createHash('sha256').update(data).digest('hex')
+}
+
+function hmacSha256Hex(secret, data) {
+    return createHmac('sha256', secret).update(data).digest('hex')
+}
+
+function stampRequest(integrationKey, integratorSecret, method, url, body) {
+    const parsed = new URL(url)
+    const params = [...parsed.searchParams.keys()].sort()
+    const qs = params
+        .map(
+            (key) =>
+                `${encodeURIComponent(key)}=${encodeURIComponent(parsed.searchParams.get(key))}`
+        )
+        .join('&')
+    const path = qs ? `${parsed.pathname}?${qs}` : parsed.pathname
+    const timestamp = Date.now()
+    const bodyHash = body ? sha256Hex(body) : ''
+    const payload = `${timestamp}.${method.toUpperCase()}.${path}.${bodyHash}`
+    const signature = `sha256=${hmacSha256Hex(integratorSecret, payload)}`
+
+    return {
+        'X-Integrator-Key': integrationKey,
+        'X-Signature': signature,
+        'X-Timestamp': String(timestamp),
+    }
+}
+
+async function requestJson(url, options) {
+    const response = await fetch(url, options)
+    const text = await response.text()
+    const body = text ? JSON.parse(text) : null
+
+    if (!response.ok) {
+        const message = body?.detail || body?.title || body?.error || `HTTP ${response.status}`
+        throw new Error(`${message} (${response.status})`)
+    }
+
+    return body
+}
+
+async function createSandboxUser(req, res) {
+    const body = await readJsonBody(req)
+    const integrationKey = assertString(body.integrationKey, 'integrationKey')
+    const email =
+        body.fresh === true
+            ? `ach-qc+${Date.now()}@spritz.finance`
+            : typeof body.email === 'string' && body.email.trim()
+              ? body.email.trim()
+              : `ach-qc+${Date.now()}@spritz.finance`
+
+    const user = await requestJson(`${legacySandboxBaseUrl}/users/integration`, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            'X-INTEGRATION-KEY': integrationKey,
+        },
+        body: JSON.stringify({ email }),
+    })
+
+    sendJson(res, 200, {
+        userId: user.userId,
+        email: user.email,
+        apiKey: user.apiKey,
+    })
+}
+
+async function bypassSandboxKyc(req, res) {
+    const body = await readJsonBody(req)
+    const integrationKey = assertString(body.integrationKey, 'integrationKey')
+    const integratorSecret = assertString(body.integratorSecret, 'integratorSecret')
+    const apiKey = assertString(body.apiKey, 'apiKey')
+    const country =
+        typeof body.country === 'string' && body.country.trim() ? body.country.trim() : 'US'
+    const url = `${sandboxRestBaseUrl}/v1/sandbox/bypass-kyc`
+    const requestBody = JSON.stringify({ country })
+
+    const result = await requestJson(url, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+            ...stampRequest(integrationKey, integratorSecret, 'POST', url, requestBody),
+        },
+        body: requestBody,
+    })
+
+    sendJson(res, 200, { country, result })
+}
+
+function selectedResponseHeaders(headers) {
+    const selected = {}
+    for (const name of [
+        'x-request-id',
+        'x-trace-id',
+        'x-correlation-id',
+        'x-amzn-requestid',
+        'x-amzn-trace-id',
+        'request-id',
+        'trace-id',
+    ]) {
+        const value = headers.get(name)
+        if (value) selected[name] = value
+    }
+    return selected
+}
+
+async function sandboxApiProxy(req, res) {
+    const body = await readJsonBody(req)
+    const method = assertString(body.method, 'method').toUpperCase()
+    const path = assertString(body.path, 'path')
+    const integrationKey = assertString(body.integrationKey, 'integrationKey')
+    const integratorSecret = assertString(body.integratorSecret, 'integratorSecret')
+    const apiKey = assertString(body.apiKey, 'apiKey')
+
+    if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+        throw new Error(`Unsupported method: ${method}`)
+    }
+    if (!path.startsWith('/v1/')) {
+        throw new Error('Only /v1 sandbox API paths are allowed')
+    }
+
+    const url = `${sandboxRestBaseUrl}${path}`
+    const requestBody =
+        body.body === undefined || body.body === null ? null : JSON.stringify(body.body)
+    const response = await fetch(url, {
+        method,
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+            ...stampRequest(integrationKey, integratorSecret, method, url, requestBody),
+        },
+        ...(requestBody ? { body: requestBody } : {}),
+    })
+    const text = await response.text()
+    let responseBody = null
+
+    try {
+        responseBody = text ? JSON.parse(text) : null
+    } catch {
+        responseBody = text
+    }
+
+    sendJson(res, 200, {
+        status: response.status,
+        ok: response.ok,
+        headers: selectedResponseHeaders(response.headers),
+        body: responseBody,
+    })
+}
+
+async function loadSdkModule() {
+    try {
+        sdkModulePromise ??= import(pathToFileURL(sdkModulePath).href)
+        return await sdkModulePromise
+    } catch {
+        sdkModulePromise = null
+        throw new Error(
+            `Unable to load built SDK from ${sdkModulePath}. Run yarn build, then restart the evidence server.`
+        )
+    }
+}
+
+async function createSdkClient({ integrationKey, integratorSecret, apiKey }) {
+    const { Environment, SpritzApiClient } = await loadSdkModule()
+    return SpritzApiClient.initialize({
+        environment: Environment.Sandbox,
+        integrationKey,
+        integratorSecret,
+        apiKey,
+    })
+}
+
+async function invokeSdkAction(client, action, input) {
+    switch (action) {
+        case 'bankAccount.createLinkToken':
+            return client.bankAccount.createLinkToken()
+        case 'bankAccount.completeLinking':
+            return client.bankAccount.completeLinking(assertObject(input, 'input'))
+        case 'fundingSource.list':
+            return client.fundingSource.list()
+        case 'fundingSource.get':
+            return client.fundingSource.get(assertString(input?.fundingSourceId, 'fundingSourceId'))
+        case 'fundingSource.getDepositLimits':
+            return client.fundingSource.getDepositLimits(
+                assertString(input?.fundingSourceId, 'fundingSourceId')
+            )
+        case 'deposit.prepare':
+            return client.deposit.prepare(assertObject(input, 'input'))
+        case 'deposit.create':
+            return client.deposit.create(assertObject(input, 'input'))
+        case 'sandbox.bypassKyc':
+            return client.sandbox.bypassKyc(input?.country ? { country: input.country } : undefined)
+        case 'sandbox.createDepositWithReturn':
+            return client.sandbox.createDepositWithReturn(assertObject(input, 'input'))
+        case 'onrampPayment.list':
+            return client.onrampPayment.list(optionalQuery(input))
+        case 'onrampPayment.get':
+            return client.onrampPayment.get(assertString(input?.onRampId, 'onRampId'))
+        case 'achDebitReturn.list':
+            return client.achDebitReturn.list(optionalQuery(input))
+        case 'achDebitReturn.get':
+            return client.achDebitReturn.get(assertString(input?.returnId, 'returnId'))
+        default:
+            throw new Error(`Unsupported SDK action: ${action}`)
+    }
+}
+
+function serializeSdkError(error) {
+    if (error instanceof Error) {
+        return {
+            name: error.name,
+            message: error.message,
+            status: 'status' in error ? error.status : undefined,
+            headers: 'headers' in error ? error.headers : undefined,
+            timestamp: 'timestamp' in error ? error.timestamp : undefined,
+            error: 'error' in error ? error.error : undefined,
+            cause:
+                error.cause instanceof Error
+                    ? { name: error.cause.name, message: error.cause.message }
+                    : undefined,
+        }
+    }
+
+    return {
+        name: 'Error',
+        message: String(error),
+    }
+}
+
+async function sdkCall(req, res) {
+    const body = await readJsonBody(req)
+    const action = assertString(body.action, 'action')
+    const integrationKey = assertString(body.integrationKey, 'integrationKey')
+    const integratorSecret = assertString(body.integratorSecret, 'integratorSecret')
+    const apiKey = assertString(body.apiKey, 'apiKey')
+
+    try {
+        const client = await createSdkClient({ integrationKey, integratorSecret, apiKey })
+        const result = await invokeSdkAction(client, action, body.input)
+
+        sendJson(res, 200, {
+            ok: true,
+            action,
+            body: result ?? null,
+        })
+    } catch (error) {
+        sendJson(res, 200, {
+            ok: false,
+            action,
+            error: serializeSdkError(error),
+        })
+    }
+}
+
+function validateEvidence(payload) {
+    if (!payload || typeof payload !== 'object') {
+        throw new Error('Evidence payload must be an object')
+    }
+    if (!Array.isArray(payload.events)) {
+        throw new Error('Evidence payload must include events[]')
+    }
+    if (payload.environment !== 'sandbox') {
+        throw new Error('Evidence payload must be for sandbox')
+    }
+}
+
+const server = createServer(async (req, res) => {
+    const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`)
+
+    if (req.method === 'OPTIONS') {
+        sendJson(res, 204, {})
+        return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+        sendJson(res, 200, { ok: true, outputDir })
+        return
+    }
+
+    if ((req.method === 'GET' || req.method === 'HEAD') && url.pathname !== '/evidence') {
+        await sendStatic(req, res, decodeURIComponent(url.pathname))
+        return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/sandbox-user/create') {
+        try {
+            await createSandboxUser(req, res)
+        } catch (error) {
+            sendJson(res, 400, {
+                ok: false,
+                error: error instanceof Error ? error.message : 'Failed to create sandbox user',
+            })
+        }
+        return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/sandbox-user/bypass-kyc') {
+        try {
+            await bypassSandboxKyc(req, res)
+        } catch (error) {
+            sendJson(res, 400, {
+                ok: false,
+                error: error instanceof Error ? error.message : 'Failed to bypass sandbox KYC',
+            })
+        }
+        return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/sandbox-api') {
+        try {
+            await sandboxApiProxy(req, res)
+        } catch (error) {
+            sendJson(res, 400, {
+                ok: false,
+                error: error instanceof Error ? error.message : 'Failed to proxy sandbox API call',
+            })
+        }
+        return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/sdk-call') {
+        try {
+            await sdkCall(req, res)
+        } catch (error) {
+            sendJson(res, 400, {
+                ok: false,
+                error: error instanceof Error ? error.message : 'Failed to run SDK call',
+            })
+        }
+        return
+    }
+
+    if (req.method !== 'POST' || url.pathname !== '/evidence') {
+        sendJson(res, 404, { ok: false, error: 'Not found' })
+        return
+    }
+
+    try {
+        const payload = await readJsonBody(req)
+        validateEvidence(payload)
+
+        await mkdir(outputDir, { recursive: true })
+        const filePath = resolve(outputDir, safeFileName(payload.runId))
+        await writeFile(
+            filePath,
+            `${JSON.stringify({ ...payload, receivedAt: new Date().toISOString() }, null, 2)}\n`
+        )
+
+        sendJson(res, 200, { ok: true, path: filePath })
+    } catch (error) {
+        sendJson(res, 400, {
+            ok: false,
+            error: error instanceof Error ? error.message : 'Invalid evidence payload',
+        })
+    }
+})
+
+server.listen(port, host, () => {
+    console.log(`ACH QC example app listening at http://${host}:${port}/ach-onramp.html`)
+    console.log(`ACH QC evidence receiver listening at http://${host}:${port}/evidence`)
+    console.log(`Writing evidence to ${outputDir}`)
+})

--- a/scripts/sandbox/evidence-server.mjs
+++ b/scripts/sandbox/evidence-server.mjs
@@ -25,6 +25,14 @@ function sendJson(res, status, body) {
     res.end(JSON.stringify(body))
 }
 
+function sendBadRequest(res, error, message) {
+    console.error(error)
+    sendJson(res, 400, {
+        ok: false,
+        error: message,
+    })
+}
+
 function contentType(filePath) {
     switch (extname(filePath)) {
         case '.html':
@@ -414,10 +422,7 @@ const server = createServer(async (req, res) => {
         try {
             await createSandboxUser(req, res)
         } catch (error) {
-            sendJson(res, 400, {
-                ok: false,
-                error: error instanceof Error ? error.message : 'Failed to create sandbox user',
-            })
+            sendBadRequest(res, error, 'Failed to create sandbox user')
         }
         return
     }
@@ -426,10 +431,7 @@ const server = createServer(async (req, res) => {
         try {
             await bypassSandboxKyc(req, res)
         } catch (error) {
-            sendJson(res, 400, {
-                ok: false,
-                error: error instanceof Error ? error.message : 'Failed to bypass sandbox KYC',
-            })
+            sendBadRequest(res, error, 'Failed to bypass sandbox KYC')
         }
         return
     }
@@ -438,10 +440,7 @@ const server = createServer(async (req, res) => {
         try {
             await sandboxApiProxy(req, res)
         } catch (error) {
-            sendJson(res, 400, {
-                ok: false,
-                error: error instanceof Error ? error.message : 'Failed to proxy sandbox API call',
-            })
+            sendBadRequest(res, error, 'Failed to proxy sandbox API call')
         }
         return
     }
@@ -450,10 +449,7 @@ const server = createServer(async (req, res) => {
         try {
             await sdkCall(req, res)
         } catch (error) {
-            sendJson(res, 400, {
-                ok: false,
-                error: error instanceof Error ? error.message : 'Failed to run SDK call',
-            })
+            sendBadRequest(res, error, 'Failed to run SDK call')
         }
         return
     }
@@ -476,10 +472,7 @@ const server = createServer(async (req, res) => {
 
         sendJson(res, 200, { ok: true, path: filePath })
     } catch (error) {
-        sendJson(res, 400, {
-            ok: false,
-            error: error instanceof Error ? error.message : 'Invalid evidence payload',
-        })
+        sendBadRequest(res, error, 'Invalid evidence payload')
     }
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,3 +71,9 @@ export type {
     operations as RestApiOperations,
 } from './rest/__generated__/api'
 export type { PathResponse, PathRequestBody, PathQuery, PathParams } from './rest/types'
+export type {
+    CreateWebhookParams,
+    IntegratorWebhook,
+    UpdateWebhookSecretResponse,
+    WebhookEvent,
+} from './modules/webhook/webhookService'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,21 @@
 export { SpritzApiClient } from './spritzApiClient'
 export type { ClientOptions } from './spritzApiClient'
 export * from './env'
+export {
+    APIConnectionError,
+    APIConnectionTimeoutError,
+    APIError,
+    APIUserAbortError,
+    AuthenticationError,
+    BadRequestError,
+    ConflictError,
+    InternalServerError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+    SpritzApiError,
+    UnprocessableEntityError,
+} from './lib/error'
 export type {
     CreateDirectPaymentInput,
     BankAccountInput,
@@ -74,6 +89,7 @@ export type { PathResponse, PathRequestBody, PathQuery, PathParams } from './res
 export type {
     CreateWebhookParams,
     IntegratorWebhook,
+    UpdateWebhookParams,
     UpdateWebhookSecretResponse,
     WebhookEvent,
 } from './modules/webhook/webhookService'

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,10 @@ export {
 export { onrampSupportedTokens } from './modules/virtualAccounts/types'
 export type { CreateVirtualAccountInput } from './modules/virtualAccounts/types'
 export type { PaymentLimitsResponse } from './modules/payment/paymentService'
-export type { FundingSource } from './modules/fundingSource/fundingSourceService'
+export type {
+    FundingSource,
+    FundingSourceDepositLimits,
+} from './modules/fundingSource/fundingSourceService'
 export type {
     Deposit,
     PrepareDepositRequest,

--- a/src/lib/error.test.ts
+++ b/src/lib/error.test.ts
@@ -17,23 +17,50 @@ describe('APIError', () => {
     }
 
     it('uses RFC 7807 detail as the partner-facing message', () => {
-        const error = APIError.generate(
-            400,
-            {
-                type: 'urn:problem-type:validation:invalid-input',
-                title: 'Invalid Input',
-                status: 400,
-                detail: 'amountUsd must be a positive decimal string',
-            },
-            undefined,
-            headers
-        )
+        const problem = {
+            type: 'urn:problem-type:validation:invalid-input',
+            title: 'Invalid Input',
+            status: 400,
+            detail: 'amountUsd must be a positive decimal string',
+        }
+        const error = APIError.generate(400, problem, undefined, headers)
 
         expect(error).toBeInstanceOf(BadRequestError)
         expect(error.name).toBe('BadRequestError')
         expect(error.status).toBe(400)
         expect(error.message).toBe('amountUsd must be a positive decimal string')
+        expect(error.error).toEqual(problem)
         expect(error.headers).toEqual(headers)
+    })
+
+    it('preserves RFC 7807 requirement payload for SDK consumers', () => {
+        const error = APIError.generate(
+            403,
+            {
+                type: 'urn:problem-type:forbidden',
+                title: 'Identity Verification Required',
+                status: 403,
+                detail: 'You must complete identity verification to access this feature.',
+                requirement: {
+                    type: 'identity_verification',
+                    description: 'Verify your identity to unlock platform features',
+                    status: 'not_started',
+                },
+            },
+            undefined,
+            headers
+        )
+
+        expect(error).toBeInstanceOf(PermissionDeniedError)
+        expect(error.status).toBe(403)
+        expect(error.message).toBe(
+            'You must complete identity verification to access this feature.'
+        )
+        expect(error.error?.requirement).toEqual({
+            type: 'identity_verification',
+            description: 'Verify your identity to unlock platform features',
+            status: 'not_started',
+        })
     })
 
     it('falls back to RFC 7807 title when detail is absent', () => {

--- a/src/lib/error.test.ts
+++ b/src/lib/error.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+    APIConnectionError,
+    APIError,
+    AuthenticationError,
+    BadRequestError,
+    InternalServerError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+} from './error'
+
+describe('APIError', () => {
+    const headers = {
+        requestId: 'req_123',
+        traceId: 'trace_123',
+    }
+
+    it('uses RFC 7807 detail as the partner-facing message', () => {
+        const error = APIError.generate(
+            400,
+            {
+                type: 'urn:problem-type:validation:invalid-input',
+                title: 'Invalid Input',
+                status: 400,
+                detail: 'amountUsd must be a positive decimal string',
+            },
+            undefined,
+            headers
+        )
+
+        expect(error).toBeInstanceOf(BadRequestError)
+        expect(error.name).toBe('BadRequestError')
+        expect(error.status).toBe(400)
+        expect(error.message).toBe('amountUsd must be a positive decimal string')
+        expect(error.headers).toEqual(headers)
+    })
+
+    it('falls back to RFC 7807 title when detail is absent', () => {
+        const error = APIError.generate(
+            403,
+            {
+                type: 'urn:problem-type:auth:forbidden',
+                title: 'ACH debit is not enabled for this integrator',
+                status: 403,
+            },
+            undefined,
+            headers
+        )
+
+        expect(error).toBeInstanceOf(PermissionDeniedError)
+        expect(error.status).toBe(403)
+        expect(error.message).toBe('ACH debit is not enabled for this integrator')
+        expect(error.headers?.requestId).toBe('req_123')
+    })
+
+    it('keeps legacy message payload support', () => {
+        const error = APIError.generate(
+            404,
+            {
+                message: 'Funding source not found',
+            },
+            undefined,
+            headers
+        )
+
+        expect(error).toBeInstanceOf(NotFoundError)
+        expect(error.status).toBe(404)
+        expect(error.message).toBe('Funding source not found')
+    })
+
+    it('falls back to non-JSON response text when no error payload is parsed', () => {
+        const error = APIError.generate(500, undefined, 'upstream unavailable', headers)
+
+        expect(error).toBeInstanceOf(InternalServerError)
+        expect(error.message).toBe('upstream unavailable')
+        expect(error.headers?.traceId).toBe('trace_123')
+    })
+
+    it('maps common HTTP statuses to specific error classes', () => {
+        expect(
+            APIError.generate(401, { title: 'Unauthorized' }, undefined, headers)
+        ).toBeInstanceOf(AuthenticationError)
+        expect(
+            APIError.generate(429, { title: 'Rate Limited' }, undefined, headers)
+        ).toBeInstanceOf(RateLimitError)
+    })
+
+    it('preserves connection errors for missing HTTP status', () => {
+        const error = APIError.generate(
+            undefined,
+            { message: 'network down' },
+            undefined,
+            undefined
+        )
+
+        expect(error).toBeInstanceOf(APIConnectionError)
+        expect(error.status).toBeUndefined()
+        expect(error.message).toBe('Connection error.')
+    })
+})

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -42,6 +42,7 @@ export class SpritzApiError extends Error {
 
 export class APIError extends Error {
     readonly status: number | undefined
+    readonly error: APIErrorPayload | undefined
     readonly headers: Headers | undefined
     readonly timestamp: string
 
@@ -53,6 +54,7 @@ export class APIError extends Error {
     ) {
         super(APIError.makeMessage(error, message))
         this.status = status
+        this.error = error
         this.headers = headers
         this.timestamp = new Date().toISOString()
     }

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -14,6 +14,19 @@ function stringifyError(value: unknown): string {
     }
 }
 
+function getStringField(error: unknown, field: string): string | undefined {
+    if (!error || typeof error !== 'object' || !(field in error)) {
+        return undefined
+    }
+
+    const value = (error as Record<string, unknown>)[field]
+    if (typeof value === 'string' && value.length > 0) {
+        return value
+    }
+
+    return undefined
+}
+
 export class SpritzApiError extends Error {
     readonly timestamp: string
     readonly headers: Headers
@@ -45,10 +58,14 @@ export class APIError extends Error {
     }
 
     private static makeMessage(error: unknown, message: string | undefined) {
-        if (error && typeof error === 'object' && 'message' in error) {
-            const errorMessage = error.message
-            return typeof errorMessage === 'string' ? errorMessage : stringifyError(errorMessage)
-        }
+        const problemDetail = getStringField(error, 'detail')
+        if (problemDetail) return problemDetail
+
+        const problemTitle = getStringField(error, 'title')
+        if (problemTitle) return problemTitle
+
+        const errorMessage = getStringField(error, 'message')
+        if (errorMessage) return errorMessage
 
         if (error !== undefined) {
             return stringifyError(error)

--- a/src/modules/achDebitReturn/achDebitReturnService.test.ts
+++ b/src/modules/achDebitReturn/achDebitReturnService.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpritzClient } from '../../lib/client'
+import { AchDebitReturnService } from './achDebitReturnService'
+
+describe('AchDebitReturnService', () => {
+    let achDebitReturnService: AchDebitReturnService
+    let mockClient: SpritzClient
+
+    beforeEach(() => {
+        mockClient = {
+            restApi: vi.fn(),
+        } as unknown as SpritzClient
+
+        achDebitReturnService = new AchDebitReturnService(mockClient)
+    })
+
+    it('lists ACH debit returns with filters', async () => {
+        const query = {
+            limit: 50,
+            cursor: 'cursor_123',
+            userId: 'user_123',
+            userIds: 'user_123,user_456',
+            search: 'R01',
+            returnCode: 'R01',
+            returnBucket: 'administrative',
+            cryptoStateAtReturn: 'fully_confirmed',
+            lossOnly: 'true',
+            userAction: 'review_required',
+            occurredAfter: '2026-01-01T00:00:00Z',
+            occurredBefore: '2026-02-01T00:00:00Z',
+        } as const
+        const response = {
+            data: [],
+            hasMore: false,
+            nextCursor: null,
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await achDebitReturnService.list(query)
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'get',
+            path: '/v1/integrator/ach-debit/returns',
+            query,
+        })
+        expect(result).toEqual(response)
+    })
+
+    it('gets an ACH debit return by URL-encoded ID', async () => {
+        const response = {
+            id: 'dr_123',
+            depositId: 'dep_123',
+            userId: 'user_123',
+            sourceId: 'fs_123',
+            onRampId: 'onramp_123',
+            amountUsd: '100.00',
+            currency: 'USD',
+            returnCode: 'R01',
+            returnReason: 'Insufficient funds',
+            occurredAt: '2026-01-01T00:00:00Z',
+            cryptoStateAtReturn: 'fully_confirmed',
+            lossAmountUsd: '100.00',
+            atRiskAmountUsd: '0.00',
+            sourceAction: 'disabled',
+            userAction: 'none',
+            reportingBucket: 'administrative',
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await achDebitReturnService.get('dr_123/with space')
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'get',
+            path: '/v1/integrator/ach-debit/returns/dr_123%2Fwith%20space',
+        })
+        expect(result).toEqual(response)
+    })
+})

--- a/src/modules/bankAccount/bankAccountService.test.ts
+++ b/src/modules/bankAccount/bankAccountService.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpritzClient } from '../../lib/client'
+import { BankAccountService } from './bankAccountService'
+
+describe('BankAccountService ACH linking', () => {
+    let bankAccountService: BankAccountService
+    let mockClient: SpritzClient
+
+    beforeEach(() => {
+        mockClient = {
+            restApi: vi.fn(),
+        } as unknown as SpritzClient
+
+        bankAccountService = new BankAccountService(mockClient)
+    })
+
+    it('creates a Plaid link token', async () => {
+        const response = {
+            linkToken: 'link-sandbox-123',
+            hostedLinkUrl: 'https://plaid.example/link',
+            expiration: '2026-01-01T00:00:00Z',
+            requestId: 'req_123',
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await bankAccountService.createLinkToken()
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'post',
+            path: '/v1/bank-accounts/link-token',
+        })
+        expect(result).toEqual(response)
+    })
+
+    it('completes Plaid linking with selected account metadata', async () => {
+        const input = {
+            publicToken: 'public-sandbox-123',
+            accountIds: ['plaid-account-123'],
+            institutionId: 'ins_123',
+            institutionName: 'Plaid Test Bank',
+        }
+        const response = {
+            bankAccounts: [
+                {
+                    id: 'ba_123',
+                    status: 'active',
+                    accountHolderName: 'Test User',
+                    institution: {
+                        name: 'Plaid Test Bank',
+                        logo: null,
+                    },
+                    supportedRails: ['ach_standard'],
+                    label: 'Plaid Test Bank Checking',
+                    createdAt: '2026-01-01T00:00:00Z',
+                    fundingSourceId: 'fs_123',
+                    type: 'us',
+                    currency: 'USD',
+                    accountNumberLast4: '6789',
+                    routingNumberLast4: '0021',
+                    accountSubtype: 'checking',
+                },
+            ],
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await bankAccountService.completeLinking(input)
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'post',
+            path: '/v1/bank-accounts/link-complete',
+            body: input,
+        })
+        expect(result).toEqual(response)
+    })
+})

--- a/src/modules/deposit/depositService.test.ts
+++ b/src/modules/deposit/depositService.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpritzClient } from '../../lib/client'
+import { DepositService } from './depositService'
+
+describe('DepositService', () => {
+    let depositService: DepositService
+    let mockClient: SpritzClient
+
+    beforeEach(() => {
+        mockClient = {
+            restApi: vi.fn(),
+        } as unknown as SpritzClient
+
+        depositService = new DepositService(mockClient)
+    })
+
+    it('prepares a direct ACH deposit quote', async () => {
+        const input = {
+            sourceId: 'fs_123',
+            address: '9n4nbM75f5Ui33ZbPYXn59EwSb9Y1zdyu3x2b1f8jQRY',
+            network: 'solana',
+            asset: 'USDC',
+            quoteType: 'exact_input',
+            amountUsd: '100.00',
+            priority: 'normal',
+            feeSubsidy: {
+                percentage: 50,
+                maxAmountUsd: '5.00',
+            },
+            clientContext: {
+                sessionId: 'session_123',
+                platform: 'ios',
+            },
+        } as const
+        const response = {
+            preparationId: 'prep_123',
+            kind: 'deposit_authorization',
+            expiresAt: '2026-01-01T00:00:00Z',
+            messageVersion: 'v1',
+            message: 'Authorization text',
+            summary: {
+                quoteType: 'exact_input',
+                requestedAmountUsd: '100.00',
+                priority: 'normal',
+                feeRateBps: 100,
+                principalAmountUsd: '99.00',
+                expectedAssetAmount: '99.00',
+                grossFeeUsd: '1.00',
+                feeSubsidyUsd: '0.50',
+                userFeeUsd: '0.50',
+                totalDebitAmountUsd: '100.00',
+                feeSubsidy: {
+                    percentage: 50,
+                    percentageBps: 5000,
+                    maxAmountUsd: '5.00',
+                    appliedAmountUsd: '0.50',
+                },
+                network: 'solana',
+                asset: 'USDC',
+                assetAddress: 'usdc_asset',
+                destinationAddress: input.address,
+            },
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await depositService.prepare(input)
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'post',
+            path: '/v1/deposits/direct/prepare',
+            body: input,
+        })
+        expect(result).toEqual(response)
+    })
+
+    it('creates a direct ACH deposit from a preparation', async () => {
+        const input = {
+            preparationId: 'prep_123',
+            clientContext: {
+                userAgent: 'test-agent',
+            },
+        }
+        const response = {
+            id: 'dep_123',
+            sourceId: 'fs_123',
+            destinationId: 'dd_123',
+            status: 'authorized',
+            debitStatus: 'authorized',
+            releaseStatus: 'not_started',
+            releaseDecisionMode: 'after_settlement',
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await depositService.create(input)
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'post',
+            path: '/v1/deposits/direct',
+            body: input,
+        })
+        expect(result).toEqual(response)
+    })
+})

--- a/src/modules/fundingSource/fundingSourceService.test.ts
+++ b/src/modules/fundingSource/fundingSourceService.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpritzClient } from '../../lib/client'
+import { FundingSourceService } from './fundingSourceService'
+
+describe('FundingSourceService', () => {
+    let fundingSourceService: FundingSourceService
+    let mockClient: SpritzClient
+
+    beforeEach(() => {
+        mockClient = {
+            restApi: vi.fn(),
+        } as unknown as SpritzClient
+
+        fundingSourceService = new FundingSourceService(mockClient)
+    })
+
+    it('lists funding sources', async () => {
+        const sources = [
+            {
+                id: 'fs_123',
+                bankAccountId: 'ba_123',
+                institutionName: 'Test Bank',
+                accountNumberLast4: '6789',
+                accountType: 'checking',
+                status: 'active',
+                statusReason: null,
+                ownershipMatchStatus: 'matched',
+            },
+        ]
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(sources)
+
+        const result = await fundingSourceService.list()
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'get',
+            path: '/v1/funding-sources/',
+        })
+        expect(result).toEqual(sources)
+    })
+
+    it('gets a funding source by URL-encoded ID', async () => {
+        const source = {
+            id: 'fs_123/with space',
+            bankAccountId: 'ba_123',
+            institutionName: 'Test Bank',
+            accountNumberLast4: '6789',
+            accountType: 'checking',
+            status: 'active',
+            statusReason: null,
+            ownershipMatchStatus: 'matched',
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(source)
+
+        const result = await fundingSourceService.get('fs_123/with space')
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'get',
+            path: '/v1/funding-sources/fs_123%2Fwith%20space',
+        })
+        expect(result).toEqual(source)
+    })
+
+    it('gets deposit limits by URL-encoded funding source ID', async () => {
+        const limits = {
+            minimumDepositAmountUsd: '10.00',
+            transactionLimitUsd: '500.00',
+            dailyLimitUsd: '1500.00',
+            dailyRemainingUsd: '1400.00',
+            monthlyLimitUsd: '5000.00',
+            monthlyRemainingUsd: '4900.00',
+            unsettledDepositLimit: 1,
+            unsettledDepositRemaining: 1,
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(limits)
+
+        const result = await fundingSourceService.getDepositLimits('fs_123/with space')
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'get',
+            path: '/v1/funding-sources/fs_123%2Fwith%20space/deposit-limits',
+        })
+        expect(result).toEqual(limits)
+    })
+})

--- a/src/modules/fundingSource/fundingSourceService.ts
+++ b/src/modules/fundingSource/fundingSourceService.ts
@@ -2,6 +2,10 @@ import { SpritzClient } from '../../lib/client'
 import type { PathResponse } from '../../rest/types'
 
 export type FundingSource = PathResponse<'/v1/funding-sources/', 'get'>[number]
+export type FundingSourceDepositLimits = PathResponse<
+    '/v1/funding-sources/{fundingSourceId}/deposit-limits',
+    'get'
+>
 
 export class FundingSourceService {
     private client: SpritzClient
@@ -21,6 +25,13 @@ export class FundingSourceService {
         return this.client.restApi<PathResponse<'/v1/funding-sources/{fundingSourceId}', 'get'>>({
             method: 'get',
             path: `/v1/funding-sources/${encodeURIComponent(fundingSourceId)}`,
+        })
+    }
+
+    public async getDepositLimits(fundingSourceId: string) {
+        return this.client.restApi<FundingSourceDepositLimits>({
+            method: 'get',
+            path: `/v1/funding-sources/${encodeURIComponent(fundingSourceId)}/deposit-limits`,
         })
     }
 }

--- a/src/modules/onrampPayment/onrampPaymentService.test.ts
+++ b/src/modules/onrampPayment/onrampPaymentService.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpritzClient } from '../../lib/client'
+import { OnrampPaymentService } from './onrampPaymentService'
+
+describe('OnrampPaymentService', () => {
+    let onrampPaymentService: OnrampPaymentService
+    let mockClient: SpritzClient
+
+    beforeEach(() => {
+        mockClient = {
+            restApi: vi.fn(),
+        } as unknown as SpritzClient
+
+        onrampPaymentService = new OnrampPaymentService(mockClient)
+    })
+
+    it('lists on-ramps with filters', async () => {
+        const query = {
+            network: 'solana',
+            token: 'USDC',
+            address: '9n4nbM75f5Ui33ZbPYXn59EwSb9Y1zdyu3x2b1f8jQRY',
+            cursor: 'cursor_123',
+            limit: 20,
+            sort: 'desc',
+        } as const
+        const response = {
+            data: [],
+            hasMore: false,
+            nextCursor: null,
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await onrampPaymentService.list(query)
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'get',
+            path: '/v1/on-ramps/',
+            query,
+        })
+        expect(result).toEqual(response)
+    })
+
+    it('gets an on-ramp by URL-encoded ID', async () => {
+        const response = {
+            id: 'onramp_123',
+            status: 'processing',
+            createdAt: '2026-01-01T00:00:00Z',
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await onrampPaymentService.get('onramp_123/with space')
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'get',
+            path: '/v1/on-ramps/onramp_123%2Fwith%20space',
+        })
+        expect(result).toEqual(response)
+    })
+})

--- a/src/modules/sandbox/sandboxService.test.ts
+++ b/src/modules/sandbox/sandboxService.test.ts
@@ -70,4 +70,31 @@ describe('SandboxService', () => {
         })
         expect(result).toEqual(response)
     })
+
+    it('passes through additional generated sandbox return fields without inventing Signal fields', async () => {
+        const input = {
+            preparationId: 'prep_123',
+            clientContext: {
+                sessionId: 'session_123',
+            },
+            returnSimulation: {
+                code: 'R10',
+            },
+        }
+        const response = {
+            id: 'dep_123',
+            status: 'authorized',
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await sandboxService.createDepositWithReturn(input)
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'post',
+            path: '/v1/sandbox/deposits/direct',
+            body: input,
+        })
+        expect(result).toEqual(response)
+    })
 })

--- a/src/modules/sandbox/sandboxService.test.ts
+++ b/src/modules/sandbox/sandboxService.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpritzClient } from '../../lib/client'
+import { SandboxService } from './sandboxService'
+
+describe('SandboxService', () => {
+    let sandboxService: SandboxService
+    let mockClient: SpritzClient
+
+    beforeEach(() => {
+        mockClient = {
+            restApi: vi.fn(),
+        } as unknown as SpritzClient
+
+        sandboxService = new SandboxService(mockClient)
+    })
+
+    it('bypasses KYC with the default US country', async () => {
+        const response = { success: true }
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await sandboxService.bypassKyc()
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'post',
+            path: '/v1/sandbox/bypass-kyc',
+            body: { country: 'US' },
+        })
+        expect(result).toEqual(response)
+    })
+
+    it('bypasses KYC with explicit options', async () => {
+        const input = {
+            country: 'US',
+            failed: true,
+        }
+        const response = { success: true }
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await sandboxService.bypassKyc(input)
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'post',
+            path: '/v1/sandbox/bypass-kyc',
+            body: input,
+        })
+        expect(result).toEqual(response)
+    })
+
+    it('creates a direct deposit with an armed ACH return simulation', async () => {
+        const input = {
+            preparationId: 'prep_123',
+            returnSimulation: {
+                code: 'R01',
+            },
+        }
+        const response = {
+            id: 'dep_123',
+            status: 'authorized',
+            returnCode: null,
+        }
+
+        vi.mocked(mockClient.restApi).mockResolvedValue(response)
+
+        const result = await sandboxService.createDepositWithReturn(input)
+
+        expect(mockClient.restApi).toHaveBeenCalledWith({
+            method: 'post',
+            path: '/v1/sandbox/deposits/direct',
+            body: input,
+        })
+        expect(result).toEqual(response)
+    })
+})

--- a/src/modules/webhook/webhookService.test.ts
+++ b/src/modules/webhook/webhookService.test.ts
@@ -8,7 +8,7 @@ describe('WebhookService', () => {
 
     beforeEach(() => {
         mockClient = {
-            request: vi.fn(),
+            restApi: vi.fn(),
         } as unknown as SpritzClient
 
         webhookService = new WebhookService(mockClient)
@@ -18,45 +18,69 @@ describe('WebhookService', () => {
         it('should create a webhook', async () => {
             const mockWebhook = {
                 id: 'webhook-123',
-                integratorId: 'integrator-123',
                 failureCount: 0,
                 events: ['payment.created', 'payment.completed'],
                 url: 'https://example.com/webhook',
-                createdAt: '2024-01-01T00:00:00Z',
+                disabled: false,
             }
 
-            vi.mocked(mockClient.request).mockResolvedValue(mockWebhook)
+            vi.mocked(mockClient.restApi).mockResolvedValue(mockWebhook)
 
             const result = await webhookService.create({
                 url: 'https://example.com/webhook',
                 events: ['payment.created', 'payment.completed'],
             })
 
-            expect(mockClient.request).toHaveBeenCalledWith({
+            expect(mockClient.restApi).toHaveBeenCalledWith({
                 method: 'post',
-                path: '/users/integrators/webhooks',
+                path: '/v1/integrator/webhooks',
                 body: {
                     url: 'https://example.com/webhook',
                     events: ['payment.created', 'payment.completed'],
                 },
             })
+            expect(result).toEqual({
+                ...mockWebhook,
+                integratorId: '',
+                createdAt: '',
+            })
+        })
+
+        it('should preserve legacy webhook fields when the API includes them', async () => {
+            const mockWebhook = {
+                id: 'webhook-123',
+                integratorId: 'integrator-123',
+                failureCount: 0,
+                events: ['payment.created'],
+                url: 'https://example.com/webhook',
+                createdAt: '2024-01-01T00:00:00Z',
+                disabled: false,
+            }
+
+            vi.mocked(mockClient.restApi).mockResolvedValue(mockWebhook)
+
+            const result = await webhookService.create({
+                url: 'https://example.com/webhook',
+                events: ['payment.created'],
+            })
+
             expect(result).toEqual(mockWebhook)
         })
     })
 
     describe('updateWebhookSecret', () => {
         it('should update webhook secret', async () => {
-            const mockResponse = { success: true }
-            vi.mocked(mockClient.request).mockResolvedValue(mockResponse)
+            const mockResponse = { secretConfigured: true }
+            vi.mocked(mockClient.restApi).mockResolvedValue(mockResponse)
 
             const result = await webhookService.updateWebhookSecret('new-secret')
 
-            expect(mockClient.request).toHaveBeenCalledWith({
+            expect(mockClient.restApi).toHaveBeenCalledWith({
                 method: 'post',
-                path: '/users/integrators/webhook-secret',
+                path: '/v1/integrator/webhook-secret',
                 body: { secret: 'new-secret' },
             })
-            expect(result).toEqual(mockResponse)
+            expect(result).toEqual({ success: true })
         })
     })
 
@@ -65,53 +89,75 @@ describe('WebhookService', () => {
             const mockWebhooks = [
                 {
                     id: 'webhook-1',
-                    integratorId: 'integrator-123',
                     failureCount: 0,
                     events: ['payment.created'],
                     url: 'https://example.com/webhook1',
-                    createdAt: '2024-01-01T00:00:00Z',
+                    disabled: false,
                 },
                 {
                     id: 'webhook-2',
-                    integratorId: 'integrator-123',
                     failureCount: 2,
                     events: ['account.created', 'account.updated'],
                     url: 'https://example.com/webhook2',
-                    createdAt: '2024-01-02T00:00:00Z',
+                    disabled: true,
                 },
             ]
 
-            vi.mocked(mockClient.request).mockResolvedValue(mockWebhooks)
+            vi.mocked(mockClient.restApi).mockResolvedValue(mockWebhooks)
 
             const result = await webhookService.list()
 
-            expect(mockClient.request).toHaveBeenCalledWith({
+            expect(mockClient.restApi).toHaveBeenCalledWith({
                 method: 'get',
-                path: '/users/integrators/webhooks',
+                path: '/v1/integrator/webhooks',
             })
-            expect(result).toEqual(mockWebhooks)
+            expect(result).toEqual([
+                {
+                    ...mockWebhooks[0],
+                    integratorId: '',
+                    createdAt: '',
+                },
+                {
+                    ...mockWebhooks[1],
+                    integratorId: '',
+                    createdAt: '',
+                },
+            ])
         })
     })
 
     describe('delete', () => {
         it('should delete a webhook by id', async () => {
-            const mockDeletedWebhook = {
-                id: 'webhook-123',
-                integratorId: 'integrator-123',
+            const existingWebhook = {
+                id: 'webhook/123',
                 failureCount: 0,
-                events: ['payment.created', 'payment.completed'],
+                events: ['payment.completed'],
                 url: 'https://example.com/webhook',
-                createdAt: '2024-01-01T00:00:00Z',
+                disabled: false,
             }
-            vi.mocked(mockClient.request).mockResolvedValue(mockDeletedWebhook)
+            const mockDeletedWebhook = {
+                id: 'webhook/123',
+                deleted: true,
+            }
+            vi.mocked(mockClient.restApi)
+                .mockResolvedValueOnce([existingWebhook])
+                .mockResolvedValueOnce(mockDeletedWebhook)
 
-            const result = await webhookService.delete('webhook-123')
+            const result = await webhookService.delete('webhook/123')
 
-            expect(mockClient.request).toHaveBeenCalledWith({
-                method: 'delete',
-                path: '/users/integrators/webhooks/webhook-123',
+            expect(mockClient.restApi).toHaveBeenNthCalledWith(1, {
+                method: 'get',
+                path: '/v1/integrator/webhooks',
             })
-            expect(result).toEqual(mockDeletedWebhook)
+            expect(mockClient.restApi).toHaveBeenNthCalledWith(2, {
+                method: 'delete',
+                path: '/v1/integrator/webhooks/webhook%2F123',
+            })
+            expect(result).toEqual({
+                ...existingWebhook,
+                integratorId: '',
+                createdAt: '',
+            })
         })
     })
 })

--- a/src/modules/webhook/webhookService.test.ts
+++ b/src/modules/webhook/webhookService.test.ts
@@ -19,7 +19,7 @@ describe('WebhookService', () => {
             const mockWebhook = {
                 id: 'webhook-123',
                 failureCount: 0,
-                events: ['payment.created', 'payment.completed'],
+                events: ['onramp.created', 'onramp.updated'],
                 url: 'https://example.com/webhook',
                 disabled: false,
             }
@@ -28,7 +28,7 @@ describe('WebhookService', () => {
 
             const result = await webhookService.create({
                 url: 'https://example.com/webhook',
-                events: ['payment.created', 'payment.completed'],
+                events: ['onramp.created', 'onramp.updated'],
             })
 
             expect(mockClient.restApi).toHaveBeenCalledWith({
@@ -36,7 +36,7 @@ describe('WebhookService', () => {
                 path: '/v1/integrator/webhooks',
                 body: {
                     url: 'https://example.com/webhook',
-                    events: ['payment.created', 'payment.completed'],
+                    events: ['onramp.created', 'onramp.updated'],
                 },
             })
             expect(result).toEqual({
@@ -65,6 +65,62 @@ describe('WebhookService', () => {
             })
 
             expect(result).toEqual(mockWebhook)
+        })
+    })
+
+    describe('update', () => {
+        it('should update webhook event subscriptions', async () => {
+            const mockWebhook = {
+                id: 'webhook/123',
+                failureCount: 0,
+                events: ['achDebitReturn.created', 'achDebitReturn.updated'],
+                url: 'https://example.com/webhook',
+                disabled: false,
+            }
+
+            vi.mocked(mockClient.restApi).mockResolvedValue(mockWebhook)
+
+            const result = await webhookService.update('webhook/123', {
+                events: ['achDebitReturn.created', 'achDebitReturn.updated'],
+            })
+
+            expect(mockClient.restApi).toHaveBeenCalledWith({
+                method: 'patch',
+                path: '/v1/integrator/webhooks/webhook%2F123',
+                body: {
+                    events: ['achDebitReturn.created', 'achDebitReturn.updated'],
+                },
+            })
+            expect(result).toEqual({
+                ...mockWebhook,
+                integratorId: '',
+                createdAt: '',
+            })
+        })
+
+        it('should support subscribing to all webhook events', async () => {
+            const mockWebhook = {
+                id: 'webhook-123',
+                failureCount: 0,
+                events: ['*'],
+                url: 'https://example.com/webhook',
+                disabled: false,
+            }
+
+            vi.mocked(mockClient.restApi).mockResolvedValue(mockWebhook)
+
+            const result = await webhookService.update('webhook-123', {
+                events: ['*'],
+            })
+
+            expect(mockClient.restApi).toHaveBeenCalledWith({
+                method: 'patch',
+                path: '/v1/integrator/webhooks/webhook-123',
+                body: {
+                    events: ['*'],
+                },
+            })
+            expect(result.events).toEqual(['*'])
         })
     })
 

--- a/src/modules/webhook/webhookService.ts
+++ b/src/modules/webhook/webhookService.ts
@@ -5,6 +5,8 @@ type RestCreateWebhookRequest = PathRequestBody<'/v1/integrator/webhooks', 'post
 type RestIntegratorWebhook = PathResponse<'/v1/integrator/webhooks', 'post'>
 type RestIntegratorWebhookList = PathResponse<'/v1/integrator/webhooks', 'get'>
 type RestDeletedIntegratorWebhook = PathResponse<'/v1/integrator/webhooks/{webhookId}', 'delete'>
+type RestUpdateWebhookRequest = PathRequestBody<'/v1/integrator/webhooks/{webhookId}', 'patch'>
+type RestUpdatedIntegratorWebhook = PathResponse<'/v1/integrator/webhooks/{webhookId}', 'patch'>
 type RestUpdateWebhookSecretRequest = PathRequestBody<'/v1/integrator/webhook-secret', 'post'>
 type RestUpdateWebhookSecretResponse = PathResponse<'/v1/integrator/webhook-secret', 'post'>
 
@@ -25,11 +27,20 @@ export type CreateWebhookParams = {
     events: WebhookEvent[]
 }
 
+export type UpdateWebhookParams = {
+    events: WebhookEvent[]
+}
+
 export type UpdateWebhookSecretResponse = {
     success: boolean
 }
 
-function normalizeWebhook(webhook: RestIntegratorWebhook | RestIntegratorWebhookList[number]) {
+function normalizeWebhook(
+    webhook:
+        | RestIntegratorWebhook
+        | RestUpdatedIntegratorWebhook
+        | RestIntegratorWebhookList[number]
+) {
     const maybeLegacyWebhook = webhook as RestIntegratorWebhook & Partial<IntegratorWebhook>
 
     return {
@@ -54,6 +65,19 @@ export class WebhookService {
         const webhook = await this.client.restApi<RestIntegratorWebhook, RestCreateWebhookRequest>({
             method: 'post',
             path: '/v1/integrator/webhooks',
+            body: args,
+        })
+
+        return normalizeWebhook(webhook)
+    }
+
+    public async update(webhookId: string, args: UpdateWebhookParams) {
+        const webhook = await this.client.restApi<
+            RestUpdatedIntegratorWebhook,
+            RestUpdateWebhookRequest
+        >({
+            method: 'patch',
+            path: `/v1/integrator/webhooks/${encodeURIComponent(webhookId)}`,
             body: args,
         })
 

--- a/src/modules/webhook/webhookService.ts
+++ b/src/modules/webhook/webhookService.ts
@@ -1,28 +1,46 @@
 import { SpritzClient } from '../../lib/client'
+import type { PathRequestBody, PathResponse } from '../../rest/types'
 
-export type WebhookEvent =
-    | 'account.created'
-    | 'account.updated'
-    | 'account.deleted'
-    | 'payment.created'
-    | 'payment.updated'
-    | 'payment.completed'
-    | 'payment.refunded'
-    | 'verification.status.updated'
-    | 'capabilities.updated'
+type RestCreateWebhookRequest = PathRequestBody<'/v1/integrator/webhooks', 'post'>
+type RestIntegratorWebhook = PathResponse<'/v1/integrator/webhooks', 'post'>
+type RestIntegratorWebhookList = PathResponse<'/v1/integrator/webhooks', 'get'>
+type RestDeletedIntegratorWebhook = PathResponse<'/v1/integrator/webhooks/{webhookId}', 'delete'>
+type RestUpdateWebhookSecretRequest = PathRequestBody<'/v1/integrator/webhook-secret', 'post'>
+type RestUpdateWebhookSecretResponse = PathResponse<'/v1/integrator/webhook-secret', 'post'>
+
+export type WebhookEvent = NonNullable<RestCreateWebhookRequest['events']>[number]
 
 export type IntegratorWebhook = {
     id: string
     integratorId: string
     failureCount: number
-    events: string[]
+    events: WebhookEvent[]
     url: string
     createdAt: string
+    disabled?: boolean
 }
 
-type CreateWebhookParams = {
+export type CreateWebhookParams = {
     url: string
     events: WebhookEvent[]
+}
+
+export type UpdateWebhookSecretResponse = {
+    success: boolean
+}
+
+function normalizeWebhook(webhook: RestIntegratorWebhook | RestIntegratorWebhookList[number]) {
+    const maybeLegacyWebhook = webhook as RestIntegratorWebhook & Partial<IntegratorWebhook>
+
+    return {
+        id: webhook.id,
+        integratorId: maybeLegacyWebhook.integratorId ?? '',
+        failureCount: webhook.failureCount,
+        events: webhook.events,
+        url: webhook.url,
+        createdAt: maybeLegacyWebhook.createdAt ?? '',
+        disabled: webhook.disabled,
+    }
 }
 
 export class WebhookService {
@@ -33,32 +51,57 @@ export class WebhookService {
     }
 
     public async create(args: CreateWebhookParams) {
-        return this.client.request<IntegratorWebhook, CreateWebhookParams>({
+        const webhook = await this.client.restApi<RestIntegratorWebhook, RestCreateWebhookRequest>({
             method: 'post',
-            path: '/users/integrators/webhooks',
+            path: '/v1/integrator/webhooks',
             body: args,
         })
+
+        return normalizeWebhook(webhook)
     }
 
     public async updateWebhookSecret(secret: string) {
-        return this.client.request<{ success: boolean }, { secret: string }>({
+        const response = await this.client.restApi<
+            RestUpdateWebhookSecretResponse,
+            RestUpdateWebhookSecretRequest
+        >({
             method: 'post',
-            path: '/users/integrators/webhook-secret',
+            path: '/v1/integrator/webhook-secret',
             body: { secret },
         })
+
+        return { success: response.secretConfigured }
     }
 
     public async list() {
-        return this.client.request<IntegratorWebhook[]>({
+        const webhooks = await this.client.restApi<RestIntegratorWebhookList>({
             method: 'get',
-            path: '/users/integrators/webhooks',
+            path: '/v1/integrator/webhooks',
         })
+
+        return webhooks.map(normalizeWebhook)
     }
 
     public async delete(webhookId: string) {
-        return this.client.request<IntegratorWebhook>({
+        const existingWebhook = await this.list()
+            .then((webhooks) => webhooks.find((webhook) => webhook.id === webhookId))
+            .catch(() => undefined)
+
+        await this.client.restApi<RestDeletedIntegratorWebhook>({
             method: 'delete',
-            path: `/users/integrators/webhooks/${webhookId}`,
+            path: `/v1/integrator/webhooks/${encodeURIComponent(webhookId)}`,
         })
+
+        return (
+            existingWebhook ?? {
+                id: webhookId,
+                integratorId: '',
+                failureCount: 0,
+                events: [],
+                url: '',
+                createdAt: '',
+                disabled: true,
+            }
+        )
     }
 }

--- a/src/rest/__generated__/api.d.ts
+++ b/src/rest/__generated__/api.d.ts
@@ -1119,7 +1119,11 @@ export interface paths {
         delete: operations["deleteV1IntegratorWebhooksByWebhookId"];
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update webhook
+         * @description Updates the event subscriptions for an existing webhook. Use `*` to subscribe to all events.
+         */
+        patch: operations["patchV1IntegratorWebhooksByWebhookId"];
         trace?: never;
     };
     "/v1/integrator/webhook-secret": {
@@ -1403,6 +1407,454 @@ export interface paths {
          * @description User approves the CLI's device authorization request, selecting permissions and expiry. Mints a scoped API key.
          */
         post: operations["postV1DeviceApprove"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get embedded wallet status
+         * @description Returns the authenticated user's embedded wallet status. Always 200: branch on `status` to handle the not-yet-provisioned case (`status === "not_provisioned"`) versus an active wallet (`status === "active"`, with `data` populated).
+         */
+        get: operations["getV1Wallet-kit"];
+        put?: never;
+        /**
+         * Provision embedded wallet
+         * @description Provisions a new embedded wallet for the authenticated user from a passkey challenge. Returns 409 if a wallet already exists.
+         */
+        post: operations["postV1Wallet-kit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/accounts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List wallet accounts
+         * @description Returns the on-chain addresses derived from the authenticated user's embedded wallet. `data` is empty when no wallet has been provisioned.
+         */
+        get: operations["getV1Wallet-kitAccounts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/balances": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List wallet token balances
+         * @description Returns multichain token balances for the supplied on-chain wallet address. Results are cached briefly per address.
+         */
+        get: operations["getV1Wallet-kitBalances"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/portfolio/snapshots": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get wallet portfolio snapshots
+         * @description Returns the authenticated user's portfolio snapshot history for the requested range. `latest` and `baseline` reference the newest and oldest snapshots inside the range; `changeUsd`/`changePercent` are simple balance deltas (not P&L). New users with no snapshots return `latest`/`baseline` as null and an empty `points` array.
+         */
+        get: operations["getV1Wallet-kitPortfolioSnapshots"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/solana/transfers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Solana wallet transfers
+         * @description Returns a paginated list of Solana transfers involving the supplied address (sent or received). Results are cached briefly per address + page and invalidated when the web3 service emits `wallet-balance.invalidated`.
+         */
+        get: operations["getV1Wallet-kitSolanaTransfers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/solana/transactions/prepare": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Prepare Solana transaction
+         * @description Prepares an unsigned Solana v0 message for the authenticated user's embedded wallet to sign. Supports `transfer`, `payment`, `yield.deposit`, and `yield.withdraw` intents. Kamino is the only yield protocol supported today. The response `messageBytes` are base64-encoded Solana message bytes, not a serialized transaction; the wallet must sign the decoded bytes exactly and submit only the detached signature.
+         */
+        post: operations["postV1Wallet-kitSolanaTransactionsPrepare"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/solana/transactions/submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Solana transaction
+         * @description Submits the user's detached signature for a previously prepared Solana transaction. The server verifies the signature against the stored message, adds any Spritz-owned signatures such as the fee payer, serializes the transaction, and broadcasts it. If submit returns `TX_EXPIRED`, call prepare again and sign the new `messageBytes`. Retrying after a successful broadcast returns the existing transaction signature.
+         */
+        post: operations["postV1Wallet-kitSolanaTransactionsSubmit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/solana/transactions/{txId}/submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Solana transaction by id
+         * @description Path-based submit alias. Use this when the prepared transaction id is already part of the URL. The request body contains only `userSignature`; `txId` is taken from the path.
+         */
+        post: operations["postV1Wallet-kitSolanaTransactionsByTxIdSubmit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/auth-methods/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List wallet auth methods
+         * @description Returns the auth methods registered on the authenticated user's embedded wallet sub-organization.
+         */
+        get: operations["getV1Wallet-kitAuth-methods"];
+        put?: never;
+        /**
+         * Commit add auth method
+         * @description Submits the user's stamp for a previously prepared add-auth-method intent. Returns the newly registered auth method.
+         */
+        post: operations["postV1Wallet-kitAuth-methods"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/auth-methods/intents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Prepare add auth method
+         * @description Prepares a Turnkey activity for adding a new auth method (passkey, OAuth, or email). When a new method must be added, returns `status: "intent_required"` and an intent the wallet must stamp. When the same OAuth/email method already exists, returns `status: "already_exists"` with the existing method — no commit is needed.
+         */
+        post: operations["postV1Wallet-kitAuth-methodsIntents"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/auth-methods/email/start/intents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Prepare email OTP start
+         * @description Prepares a Turnkey activity for starting the email-OTP flow. Stamp `intent.activityBody` and call the matching commit endpoint to dispatch the OTP.
+         */
+        post: operations["postV1Wallet-kitAuth-methodsEmailStartIntents"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/auth-methods/email/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Commit email OTP start
+         * @description Submits the user's stamp for a previously prepared email-start intent. Dispatches the OTP and returns the `otpId` to pass back to the add-auth-method prepare call.
+         */
+        post: operations["postV1Wallet-kitAuth-methodsEmailStart"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/auth-methods/{id}/intents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Prepare remove auth method
+         * @description Prepares a Turnkey activity for removing an auth method. Stamp `intent.activityBody` and call DELETE with the same `intentId` and stamp. Returns 409 if the method is the user's last (`LAST_AUTH_METHOD`).
+         */
+        post: operations["postV1Wallet-kitAuth-methodsByIdIntents"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/auth-methods/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Commit remove auth method
+         * @description Submits the user's stamp for a previously prepared remove-auth-method intent. Returns 204 on success. Returns 409 if the method is the user's last (`LAST_AUTH_METHOD`).
+         */
+        delete: operations["deleteV1Wallet-kitAuth-methodsById"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/yield/solana/kamino/vaults": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Kamino yield vaults
+         * @description Returns listed USDC Kamino vaults on Solana by default. Set `includeUnlisted=true` to include unlisted vaults.
+         */
+        get: operations["getV1Wallet-kitYieldSolanaKaminoVaults"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/yield/solana/kamino/vaults/{vaultId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Kamino yield vault
+         * @description Returns one Solana Kamino vault. Unlisted vaults return 404 unless `includeUnlisted=true` is supplied.
+         */
+        get: operations["getV1Wallet-kitYieldSolanaKaminoVaultsByVaultId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/yield/solana/kamino/vaults/{vaultId}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Kamino yield vault history
+         * @description Returns time-series metrics for one Solana Kamino vault.
+         */
+        get: operations["getV1Wallet-kitYieldSolanaKaminoVaultsByVaultIdHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/yield/solana/kamino/positions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Kamino yield positions
+         * @description Returns Solana Kamino vault positions for the supplied wallet address.
+         */
+        get: operations["getV1Wallet-kitYieldSolanaKaminoPositions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/yield/solana/kamino/positions/{vaultId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Kamino yield position
+         * @description `data` is a Solana Kamino vault position for the supplied wallet address, or null when Kamino reports no position.
+         */
+        get: operations["getV1Wallet-kitYieldSolanaKaminoPositionsByVaultId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/yield/solana/kamino/positions/{vaultId}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Kamino yield position history
+         * @description Returns time-series metrics for one Solana Kamino vault position.
+         */
+        get: operations["getV1Wallet-kitYieldSolanaKaminoPositionsByVaultIdHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/yield/solana/kamino/positions/{vaultId}/pnl": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Kamino yield position PnL
+         * @description Returns aggregate PnL and cost basis for one Solana Kamino vault position.
+         */
+        get: operations["getV1Wallet-kitYieldSolanaKaminoPositionsByVaultIdPnl"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/wallet-kit/yield/solana/kamino/transactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Kamino yield transactions
+         * @description Returns Kamino vault activity for the supplied Solana wallet address. `vaultId` is optional.
+         */
+        get: operations["getV1Wallet-kitYieldSolanaKaminoTransactions"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2347,7 +2799,7 @@ export interface operations {
                 "application/json": {
                     /**
                      * @description Destination account ID
-                     * @example 69f3670e2be43101c2654dd7
+                     * @example 69fcc3849e56476d70fe629a
                      */
                     accountId: string;
                     /**
@@ -2375,7 +2827,7 @@ export interface operations {
                 "application/x-www-form-urlencoded": {
                     /**
                      * @description Destination account ID
-                     * @example 69f3670e2be43101c2654dd7
+                     * @example 69fcc3849e56476d70fe629a
                      */
                     accountId: string;
                     /**
@@ -2403,7 +2855,7 @@ export interface operations {
                 "multipart/form-data": {
                     /**
                      * @description Destination account ID
-                     * @example 69f3670e2be43101c2654dd7
+                     * @example 69fcc3849e56476d70fe629a
                      */
                     accountId: string;
                     /**
@@ -2450,7 +2902,7 @@ export interface operations {
                         /**
                          * Format: date-time
                          * @description When the quote was created
-                         * @example 2026-04-30T14:28:30.745Z
+                         * @example 2026-05-07T16:53:24.366Z
                          */
                         createdAt: string;
                         /** @description What the user pays — total USD cost and token used. */
@@ -2489,7 +2941,7 @@ export interface operations {
                             rail: "ach_standard" | "ach_same_day" | "rtp" | "wire" | "eft" | "sepa" | "faster_payments" | "push_to_card" | "bill_pay" | "card_deposit";
                             /**
                              * @description Destination account ID
-                             * @example 69f3670e2be43101c2654dd8
+                             * @example 69fcc3849e56476d70fe629b
                              */
                             accountId: string;
                         };
@@ -2696,7 +3148,7 @@ export interface operations {
                         /**
                          * Format: date-time
                          * @description When the quote was created
-                         * @example 2026-04-30T14:28:30.745Z
+                         * @example 2026-05-07T16:53:24.366Z
                          */
                         createdAt: string;
                         /** @description What the user pays — total USD cost and token used. */
@@ -2735,7 +3187,7 @@ export interface operations {
                             rail: "ach_standard" | "ach_same_day" | "rtp" | "wire" | "eft" | "sepa" | "faster_payments" | "push_to_card" | "bill_pay" | "card_deposit";
                             /**
                              * @description Destination account ID
-                             * @example 69f3670e2be43101c2654dd8
+                             * @example 69fcc3849e56476d70fe629b
                              */
                             accountId: string;
                         };
@@ -3232,7 +3684,7 @@ export interface operations {
                                 currency: string;
                                 /**
                                  * @description Destination account ID
-                                 * @example 69f3670e2be43101c2654dd9
+                                 * @example 69fcc3849e56476d70fe629c
                                  */
                                 accountId: string;
                                 accountName: (string | null) | null;
@@ -3448,7 +3900,7 @@ export interface operations {
                             currency: string;
                             /**
                              * @description Destination account ID
-                             * @example 69f3670e2be43101c2654dd9
+                             * @example 69fcc3849e56476d70fe629c
                              */
                             accountId: string;
                             accountName: (string | null) | null;
@@ -12355,7 +12807,7 @@ export interface operations {
                         accessToken: string;
                         /**
                          * @description The internal ID of the authorized user
-                         * @example 69f3670e2be43101c2654de1
+                         * @example 69fcc3849e56476d70fe62a4
                          */
                         userId: string;
                         /**
@@ -12371,7 +12823,7 @@ export interface operations {
                         /**
                          * Format: date-time
                          * @description ISO 8601 timestamp when token expires
-                         * @example 2026-04-30T15:28:30.938Z
+                         * @example 2026-05-07T17:53:24.550Z
                          */
                         expiresAt: string;
                     };
@@ -12546,7 +12998,7 @@ export interface operations {
                         /**
                          * Format: date-time
                          * @description ISO 8601 timestamp of when the integrator was created
-                         * @example 2026-04-30T14:28:30.938Z
+                         * @example 2026-05-07T16:53:24.550Z
                          */
                         createdAt: string;
                     };
@@ -12717,7 +13169,7 @@ export interface operations {
                             depositId: string;
                             /**
                              * @description Spritz user ID associated with the returned deposit
-                             * @example 69f3670e2be43101c2654de0
+                             * @example 69fcc3849e56476d70fe62a3
                              */
                             userId: string;
                             /**
@@ -12905,7 +13357,7 @@ export interface operations {
                         depositId: string;
                         /**
                          * @description Spritz user ID associated with the returned deposit
-                         * @example 69f3670e2be43101c2654de0
+                         * @example 69fcc3849e56476d70fe62a3
                          */
                         userId: string;
                         /**
@@ -13074,11 +13526,11 @@ export interface operations {
                     "application/json": {
                         /**
                          * @description Unique identifier for the webhook
-                         * @example 69f3670e2be43101c2654de2
+                         * @example 69fcc3849e56476d70fe62a5
                          */
                         id: string;
                         /** @description List of event types this webhook is subscribed to */
-                        events: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated")[];
+                        events: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated" | "onramp.created" | "onramp.updated" | "onramp.completed" | "achDebitReturn.created" | "achDebitReturn.updated" | "*")[];
                         /**
                          * Format: uri
                          * @description URL to which webhook payloads are delivered
@@ -13241,7 +13693,7 @@ export interface operations {
                      * @description List of event types to subscribe to. Defaults to empty array.
                      * @default []
                      */
-                    events?: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated")[];
+                    events?: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated" | "onramp.created" | "onramp.updated" | "onramp.completed" | "achDebitReturn.created" | "achDebitReturn.updated" | "*")[];
                 };
                 "application/x-www-form-urlencoded": {
                     /**
@@ -13254,7 +13706,7 @@ export interface operations {
                      * @description List of event types to subscribe to. Defaults to empty array.
                      * @default []
                      */
-                    events?: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated")[];
+                    events?: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated" | "onramp.created" | "onramp.updated" | "onramp.completed" | "achDebitReturn.created" | "achDebitReturn.updated" | "*")[];
                 };
                 "multipart/form-data": {
                     /**
@@ -13267,7 +13719,7 @@ export interface operations {
                      * @description List of event types to subscribe to. Defaults to empty array.
                      * @default []
                      */
-                    events?: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated")[];
+                    events?: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated" | "onramp.created" | "onramp.updated" | "onramp.completed" | "achDebitReturn.created" | "achDebitReturn.updated" | "*")[];
                 };
             };
         };
@@ -13281,11 +13733,11 @@ export interface operations {
                     "application/json": {
                         /**
                          * @description Unique identifier for the webhook
-                         * @example 69f3670e2be43101c2654de2
+                         * @example 69fcc3849e56476d70fe62a5
                          */
                         id: string;
                         /** @description List of event types this webhook is subscribed to */
-                        events: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated")[];
+                        events: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated" | "onramp.created" | "onramp.updated" | "onramp.completed" | "achDebitReturn.created" | "achDebitReturn.updated" | "*")[];
                         /**
                          * Format: uri
                          * @description URL to which webhook payloads are delivered
@@ -13456,6 +13908,188 @@ export interface operations {
                          * @constant
                          */
                         deleted: true;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 404 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         */
+                        type: string;
+                        /** @description A short, human-readable summary of the problem type */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 404
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The type of resource that was not found
+                         * @example user
+                         * @example account
+                         * @example transaction
+                         */
+                        resourceType: string;
+                        /** @description The identifier of the resource that was not found */
+                        resourceId: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    patchV1IntegratorWebhooksByWebhookId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                webhookId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description List of event types to subscribe to. Use `*` to subscribe to all events. */
+                    events: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated" | "onramp.created" | "onramp.updated" | "onramp.completed" | "achDebitReturn.created" | "achDebitReturn.updated" | "*")[];
+                };
+                "application/x-www-form-urlencoded": {
+                    /** @description List of event types to subscribe to. Use `*` to subscribe to all events. */
+                    events: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated" | "onramp.created" | "onramp.updated" | "onramp.completed" | "achDebitReturn.created" | "achDebitReturn.updated" | "*")[];
+                };
+                "multipart/form-data": {
+                    /** @description List of event types to subscribe to. Use `*` to subscribe to all events. */
+                    events: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated" | "onramp.created" | "onramp.updated" | "onramp.completed" | "achDebitReturn.created" | "achDebitReturn.updated" | "*")[];
+                };
+            };
+        };
+        responses: {
+            /** @description Response for status 200 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description Unique identifier for the webhook
+                         * @example 69fcc3849e56476d70fe62a5
+                         */
+                        id: string;
+                        /** @description List of event types this webhook is subscribed to */
+                        events: ("account.created" | "account.updated" | "account.deleted" | "payment.created" | "payment.updated" | "payment.completed" | "payment.refunded" | "verification.status.updated" | "capabilities.updated" | "onramp.created" | "onramp.updated" | "onramp.completed" | "achDebitReturn.created" | "achDebitReturn.updated" | "*")[];
+                        /**
+                         * Format: uri
+                         * @description URL to which webhook payloads are delivered
+                         * @example https://api.example.com/webhooks
+                         */
+                        url: string;
+                        /**
+                         * @description Number of consecutive delivery failures
+                         * @example 0
+                         */
+                        failureCount: number;
+                        /**
+                         * @description Whether the webhook is currently disabled
+                         * @example false
+                         */
+                        disabled: boolean;
                     };
                 };
             };
@@ -13810,7 +14444,7 @@ export interface operations {
                         /**
                          * Format: date-time
                          * @description ISO 8601 timestamp when the old secret will expire. Only present if a grace period was specified.
-                         * @example 2026-04-30T14:33:30.938Z
+                         * @example 2026-05-07T16:58:24.550Z
                          */
                         oldSecretExpiresAt?: string;
                     };
@@ -13957,7 +14591,7 @@ export interface operations {
                     "application/json": {
                         /**
                          * @description Unique identifier for the user
-                         * @example 69f3670e2be43101c2654dde
+                         * @example 69fcc3849e56476d70fe62a1
                          */
                         id: string;
                         email: (string | null) | null;
@@ -13965,7 +14599,7 @@ export interface operations {
                         /**
                          * Format: date-time
                          * @description ISO 8601 timestamp of when the user was created
-                         * @example 2026-04-30T14:28:30.933Z
+                         * @example 2026-05-07T16:53:24.483Z
                          */
                         signedUpAt: string;
                         timezone: (string | null) | null;
@@ -14295,7 +14929,7 @@ export interface operations {
                     "application/json": {
                         /**
                          * @description Unique identifier for the user
-                         * @example 69f3670e2be43101c2654dde
+                         * @example 69fcc3849e56476d70fe62a1
                          */
                         id: string;
                         email: (string | null) | null;
@@ -14303,7 +14937,7 @@ export interface operations {
                         /**
                          * Format: date-time
                          * @description ISO 8601 timestamp of when the user was created
-                         * @example 2026-04-30T14:28:30.933Z
+                         * @example 2026-05-07T16:53:24.483Z
                          */
                         signedUpAt: string;
                         timezone: (string | null) | null;
@@ -14705,7 +15339,7 @@ export interface operations {
                     "application/json": {
                         /**
                          * @description Unique identifier for the user
-                         * @example 69f3670e2be43101c2654dde
+                         * @example 69fcc3849e56476d70fe62a1
                          */
                         id: string;
                         email: (string | null) | null;
@@ -14713,7 +15347,7 @@ export interface operations {
                         /**
                          * Format: date-time
                          * @description ISO 8601 timestamp of when the user was created
-                         * @example 2026-04-30T14:28:30.933Z
+                         * @example 2026-05-07T16:53:24.483Z
                          */
                         signedUpAt: string;
                         timezone: (string | null) | null;
@@ -15712,6 +16346,5645 @@ export interface operations {
             };
             /** @description Response for status 500 */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Wallet status envelope. `data` is present only when `status === "active"`. Branch on `status` to handle the not-yet-provisioned case. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description An embedded wallet has been provisioned for this user.
+                         * @constant
+                         */
+                        status: "active";
+                        /** @description An embedded wallet for the authenticated user. Backed by a Turnkey sub-organization that holds the user's keys. */
+                        data: {
+                            /**
+                             * @description Stable wallet identifier. Pass this as the organization id when calling the Turnkey SDK.
+                             * @example 8b3f7e2a-7c5e-4a3a-8a8a-2c5e8a8a2c5e
+                             */
+                            id: string;
+                            /**
+                             * @description Wallet user identifier. Pass this as the user id when calling the Turnkey SDK.
+                             * @example e3a2c5e8-4a3a-7c5e-8a8a-2c5e8a8a2c5e
+                             */
+                            userId: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the wallet was provisioned (ISO 8601)
+                             * @example 2025-01-15T10:30:00.000Z
+                             */
+                            createdAt: string;
+                        };
+                    } | {
+                        /**
+                         * @description No embedded wallet has been provisioned for this user yet. Call POST /v1/wallet-kit to provision one.
+                         * @constant
+                         */
+                        status: "not_provisioned";
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postV1Wallet-kit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Request body for provisioning an embedded wallet. */
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Passkey/WebAuthn challenge produced by the client SDK. Forwarded directly to Turnkey to bind the user's authenticator to the new sub-organization. */
+                    challenge: string;
+                };
+                "application/x-www-form-urlencoded": {
+                    /** @description Passkey/WebAuthn challenge produced by the client SDK. Forwarded directly to Turnkey to bind the user's authenticator to the new sub-organization. */
+                    challenge: string;
+                };
+                "multipart/form-data": {
+                    /** @description Passkey/WebAuthn challenge produced by the client SDK. Forwarded directly to Turnkey to bind the user's authenticator to the new sub-organization. */
+                    challenge: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Wallet status envelope for an active (provisioned) wallet. The only response shape returned by POST /v1/wallet-kit. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description An embedded wallet has been provisioned for this user.
+                         * @constant
+                         */
+                        status: "active";
+                        /** @description An embedded wallet for the authenticated user. Backed by a Turnkey sub-organization that holds the user's keys. */
+                        data: {
+                            /**
+                             * @description Stable wallet identifier. Pass this as the organization id when calling the Turnkey SDK.
+                             * @example 8b3f7e2a-7c5e-4a3a-8a8a-2c5e8a8a2c5e
+                             */
+                            id: string;
+                            /**
+                             * @description Wallet user identifier. Pass this as the user id when calling the Turnkey SDK.
+                             * @example e3a2c5e8-4a3a-7c5e-8a8a-2c5e8a8a2c5e
+                             */
+                            userId: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the wallet was provisioned (ISO 8601)
+                             * @example 2025-01-15T10:30:00.000Z
+                             */
+                            createdAt: string;
+                        };
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 409 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitAccounts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of the authenticated user's wallet accounts. Returns an empty list when no wallet has been provisioned. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description On-chain accounts derived from the authenticated user's embedded wallet. Empty when no wallet has been provisioned. */
+                        data: {
+                            /**
+                             * @description Public on-chain address derived for this wallet
+                             * @example 0x1234567890abcdef1234567890abcdef12345678
+                             */
+                            address: string;
+                            /**
+                             * @description Turnkey address format identifier
+                             * @example ADDRESS_FORMAT_ETHEREUM
+                             * @example ADDRESS_FORMAT_SOLANA
+                             */
+                            addressFormat: string;
+                            /**
+                             * @description Turnkey curve identifier used to derive the address
+                             * @example CURVE_SECP256K1
+                             * @example CURVE_ED25519
+                             */
+                            curve: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when this account was provisioned (ISO 8601)
+                             * @example 2025-01-15T10:30:00.000Z
+                             */
+                            createdAt: string;
+                        }[];
+                        /**
+                         * @description Whether more results are available beyond `data`. Always false for this resource — the full list is returned in a single response.
+                         * @example false
+                         */
+                        hasMore: boolean;
+                        /** @description Opaque pagination cursor. Always null for this resource — the full list is returned in a single response. */
+                        nextCursor: string | null;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitBalances": {
+        parameters: {
+            query: {
+                address: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of token balances for the requested on-chain wallet address. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Multichain token balances for the requested wallet address. */
+                        data: {
+                            /**
+                             * @description Chain the token lives on
+                             * @example ethereum
+                             * @example polygon
+                             * @example solana
+                             */
+                            chain: string;
+                            /**
+                             * @description On-chain token contract address
+                             * @example 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
+                             */
+                            tokenAddress: string;
+                            /**
+                             * @description Wallet address that holds the balance
+                             * @example 0x1234567890abcdef1234567890abcdef12345678
+                             */
+                            walletAddress: string;
+                            /**
+                             * @description Token symbol
+                             * @example USDC
+                             */
+                            symbol: string;
+                            /**
+                             * @description Token name
+                             * @example USD Coin
+                             */
+                            name: string;
+                            /**
+                             * @description Token decimals
+                             * @example 6
+                             */
+                            decimals: string | number;
+                            /**
+                             * @description Decimal-formatted token balance
+                             * @example 100.5
+                             */
+                            balance: string;
+                            /**
+                             * @description Raw on-chain balance as an integer string
+                             * @example 100500000
+                             */
+                            balanceRaw: string;
+                            /**
+                             * @description Balance value in USD, formatted to two decimal places
+                             * @example 100.50
+                             */
+                            balanceUsd: string;
+                            /**
+                             * @description Token price in USD, formatted to two decimal places
+                             * @example 1.00
+                             */
+                            price: string;
+                            /**
+                             * @description URL of the token's logo image, or empty string when unknown
+                             * @example https://assets.example.com/usdc.png
+                             */
+                            tokenImageUrl: string;
+                        }[];
+                        /**
+                         * @description Whether more results are available beyond `data`. Always false for this resource — the full list is returned in a single response.
+                         * @example false
+                         */
+                        hasMore: boolean;
+                        /** @description Opaque pagination cursor. Always null for this resource — the full list is returned in a single response. */
+                        nextCursor: string | null;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitPortfolioSnapshots": {
+        parameters: {
+            query?: {
+                range?: "1d" | "7d" | "30d" | "90d" | "1y" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Portfolio snapshot history for the authenticated user's wallets. `changeUsd` and `changePercent` are simple balance deltas, not P&L. New users with no history return `latest`/`baseline` as null and `points` empty. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        range: "1d" | "7d" | "30d" | "90d" | "1y" | "all";
+                        /** @description Newest snapshot inside the requested range, or null when no snapshots exist. */
+                        latest: {
+                            /** @description Stable identifier for the snapshot point. */
+                            id: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp marking the start of the time bucket this snapshot represents.
+                             */
+                            bucketStart: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp at which the snapshot was actually captured.
+                             */
+                            capturedAt: string;
+                            /** @description `complete` when every wallet was captured successfully; `partial` when one or more wallets failed or are unsupported. */
+                            status: "complete" | "partial";
+                            /**
+                             * @description Total USD balance across all captured wallets at this point, formatted to two decimal places.
+                             * @example 1234.56
+                             */
+                            totalBalanceUsd: string;
+                            /** @description Distinct asset count at this point. */
+                            assetCount: string | number;
+                            /** @description Distinct chain count at this point. */
+                            chainCount: string | number;
+                            /** @description Total wallet count considered for this point. */
+                            walletCount: string | number;
+                            /** @description Number of wallets that were captured successfully. */
+                            capturedWalletCount: string | number;
+                            /** @description Number of wallets skipped because their chain is not yet supported. */
+                            unsupportedWalletCount: string | number;
+                            /** @description Number of wallets that failed to capture. */
+                            failedWalletCount: string | number;
+                        } | null;
+                        /** @description Oldest snapshot inside the requested range, or null when no snapshots exist. */
+                        baseline: {
+                            /** @description Stable identifier for the snapshot point. */
+                            id: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp marking the start of the time bucket this snapshot represents.
+                             */
+                            bucketStart: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp at which the snapshot was actually captured.
+                             */
+                            capturedAt: string;
+                            /** @description `complete` when every wallet was captured successfully; `partial` when one or more wallets failed or are unsupported. */
+                            status: "complete" | "partial";
+                            /**
+                             * @description Total USD balance across all captured wallets at this point, formatted to two decimal places.
+                             * @example 1234.56
+                             */
+                            totalBalanceUsd: string;
+                            /** @description Distinct asset count at this point. */
+                            assetCount: string | number;
+                            /** @description Distinct chain count at this point. */
+                            chainCount: string | number;
+                            /** @description Total wallet count considered for this point. */
+                            walletCount: string | number;
+                            /** @description Number of wallets that were captured successfully. */
+                            capturedWalletCount: string | number;
+                            /** @description Number of wallets skipped because their chain is not yet supported. */
+                            unsupportedWalletCount: string | number;
+                            /** @description Number of wallets that failed to capture. */
+                            failedWalletCount: string | number;
+                        } | null;
+                        /**
+                         * @description Simple USD balance delta between baseline and latest, formatted to two decimal places. Not P&L. Null when history is empty.
+                         * @example 12.34
+                         */
+                        changeUsd: string | null;
+                        /**
+                         * @description Simple percentage change between baseline and latest balance, formatted to two decimal places. Not P&L. Null when history is empty or baseline balance is zero.
+                         * @example 1.23
+                         */
+                        changePercent: string | null;
+                        /** @description Snapshot points inside the requested range, ordered by `bucketStart`. Empty when no history exists. */
+                        points: {
+                            /** @description Stable identifier for the snapshot point. */
+                            id: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp marking the start of the time bucket this snapshot represents.
+                             */
+                            bucketStart: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp at which the snapshot was actually captured.
+                             */
+                            capturedAt: string;
+                            /** @enum {string} */
+                            status: "complete" | "partial";
+                            /**
+                             * @description Total USD balance across all captured wallets at this point, formatted to two decimal places.
+                             * @example 1234.56
+                             */
+                            totalBalanceUsd: string;
+                            /** @description Distinct asset count at this point. */
+                            assetCount: string | number;
+                            /** @description Distinct chain count at this point. */
+                            chainCount: string | number;
+                            /** @description Total wallet count considered for this point. */
+                            walletCount: string | number;
+                            /** @description Number of wallets that were captured successfully. */
+                            capturedWalletCount: string | number;
+                            /** @description Number of wallets skipped because their chain is not yet supported. */
+                            unsupportedWalletCount: string | number;
+                            /** @description Number of wallets that failed to capture. */
+                            failedWalletCount: string | number;
+                        }[];
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitSolanaTransfers": {
+        parameters: {
+            query: {
+                address: string;
+                limit?: string | number;
+                cursor?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of Solana wallet transfers. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Solana transfers involving the requested address. */
+                        data: {
+                            /** @description Solana transaction signature (base58). Stable identifier for the transfer. */
+                            signature: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp the transaction was confirmed at.
+                             */
+                            occurredAt: string;
+                            /** @enum {string} */
+                            direction: "in" | "out";
+                            /** @description Counterparty address (sender for `in`, recipient for `out`), or null when not resolvable. */
+                            counterparty: string | null;
+                            /** @description SPL mint address. For native SOL transfers this is the wrapped SOL mint (`So111...`). */
+                            mint: string;
+                            /**
+                             * @description Token symbol.
+                             * @example SOL
+                             * @example USDC
+                             */
+                            symbol: string;
+                            /**
+                             * @description Token decimals.
+                             * @example 9
+                             * @example 6
+                             */
+                            decimals: string | number;
+                            /**
+                             * @description Decimal-formatted token amount in display units (not USD). Precision matches the token's decimals.
+                             * @example 1.5
+                             */
+                            amount: string;
+                            /**
+                             * @description Raw on-chain amount as an integer string in base units (lamports for SOL, mint base units for SPL).
+                             * @example 1500000000
+                             */
+                            amountRaw: string;
+                            /**
+                             * @description Source chain. Always `solana` for this resource.
+                             * @constant
+                             */
+                            chain: "solana";
+                        }[];
+                        /** @description Whether more results are available beyond `data`. */
+                        hasMore: boolean;
+                        /** @description Opaque pagination cursor. Pass to the next request as `cursor` to fetch the next page. Null when there are no more results. */
+                        nextCursor: string | null;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postV1Wallet-kitSolanaTransactionsPrepare": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Request body for preparing a Solana transaction. The authenticated user id is derived from the bearer token; clients do not send `userId` to Wallet Kit. The server builds and stores an unsigned Solana v0 message, then returns the exact bytes the embedded wallet must sign. */
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Caller-supplied idempotency key for this prepare call. Repeating the same `clientIntentId` with an identical intent returns the existing prepared transaction while it is active. Reusing the same key with different intent details returns a conflict error. */
+                    clientIntentId: string;
+                    /**
+                     * @description Version of the intent schema. Production prepare currently expects exactly `1`.
+                     * @example 1
+                     * @constant
+                     */
+                    intentVersion: 1;
+                    /** @enum {string} */
+                    feeMode?: "auto" | "sponsored_only" | "user_paid_only";
+                    /** @description Discriminated Solana transaction intent. Use `transfer` for wallet transfers, `payment` for Spritz off-ramp quote payments, `yield.deposit` for Kamino USDC vault deposits, and `yield.withdraw` for Kamino USDC vault withdrawals. */
+                    intent: {
+                        /**
+                         * @description Intent kind for a native SOL or SPL token transfer.
+                         * @constant
+                         */
+                        kind: "transfer";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Recipient Solana public key (base58).
+                         * @example FqVnHphYBfJTb46iWbwS8oRaAWGnLPVhWqvY1pgZ7yC8
+                         */
+                        to: string;
+                        /**
+                         * @description Positive integer amount in base units, formatted as a string. For native SOL this is lamports. For SPL tokens this is the mint's base unit, for example USDC uses 6 decimals.
+                         * @example 1000000
+                         */
+                        amount: string;
+                        /**
+                         * @description SPL mint address for token transfers, or null for native SOL transfers.
+                         * @example null
+                         */
+                        mint: string | null;
+                    } | {
+                        /**
+                         * @description Intent kind for a Spritz off-ramp quote payment.
+                         * @constant
+                         */
+                        kind: "payment";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Existing off-ramp quote id. The transaction builder resolves amount due, destination, memo/reference, and token route from this quote.
+                         * @example offramp_xyz789
+                         */
+                        offRampQuoteId: string;
+                    } | {
+                        /**
+                         * @description Intent kind for depositing USDC into a Kamino vault.
+                         * @constant
+                         */
+                        kind: "yield.deposit";
+                        /**
+                         * @description Yield protocol that will construct the deposit instructions. Only Kamino is supported for Solana yield transactions today.
+                         * @constant
+                         */
+                        protocol: "kamino";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        vault: string;
+                        /**
+                         * @description Positive integer amount in base units, formatted as a string. For native SOL this is lamports. For SPL tokens this is the mint's base unit, for example USDC uses 6 decimals.
+                         * @example 1000000
+                         */
+                        amount: string;
+                        /**
+                         * @description Solana USDC mint address supported by the selected Kamino vault.
+                         * @example EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+                         */
+                        mint: string;
+                    } | {
+                        /**
+                         * @description Intent kind for withdrawing from a Kamino vault.
+                         * @constant
+                         */
+                        kind: "yield.withdraw";
+                        /**
+                         * @description Yield protocol that will construct the withdraw instructions. Only Kamino is supported for Solana yield transactions today.
+                         * @constant
+                         */
+                        protocol: "kamino";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        vault: string;
+                        /**
+                         * @description Withdraw the user's full available position from this vault. Partial withdraws are not exposed by Wallet Kit yet.
+                         * @constant
+                         */
+                        withdrawAll: true;
+                        /**
+                         * @description Solana USDC mint address supported by the selected Kamino vault.
+                         * @example EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+                         */
+                        mint: string;
+                    };
+                };
+                "application/x-www-form-urlencoded": {
+                    /** @description Caller-supplied idempotency key for this prepare call. Repeating the same `clientIntentId` with an identical intent returns the existing prepared transaction while it is active. Reusing the same key with different intent details returns a conflict error. */
+                    clientIntentId: string;
+                    /**
+                     * @description Version of the intent schema. Production prepare currently expects exactly `1`.
+                     * @example 1
+                     * @constant
+                     */
+                    intentVersion: 1;
+                    /** @enum {string} */
+                    feeMode?: "auto" | "sponsored_only" | "user_paid_only";
+                    /** @description Discriminated Solana transaction intent. Use `transfer` for wallet transfers, `payment` for Spritz off-ramp quote payments, `yield.deposit` for Kamino USDC vault deposits, and `yield.withdraw` for Kamino USDC vault withdrawals. */
+                    intent: {
+                        /**
+                         * @description Intent kind for a native SOL or SPL token transfer.
+                         * @constant
+                         */
+                        kind: "transfer";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Recipient Solana public key (base58).
+                         * @example FqVnHphYBfJTb46iWbwS8oRaAWGnLPVhWqvY1pgZ7yC8
+                         */
+                        to: string;
+                        /**
+                         * @description Positive integer amount in base units, formatted as a string. For native SOL this is lamports. For SPL tokens this is the mint's base unit, for example USDC uses 6 decimals.
+                         * @example 1000000
+                         */
+                        amount: string;
+                        /**
+                         * @description SPL mint address for token transfers, or null for native SOL transfers.
+                         * @example null
+                         */
+                        mint: string | null;
+                    } | {
+                        /**
+                         * @description Intent kind for a Spritz off-ramp quote payment.
+                         * @constant
+                         */
+                        kind: "payment";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Existing off-ramp quote id. The transaction builder resolves amount due, destination, memo/reference, and token route from this quote.
+                         * @example offramp_xyz789
+                         */
+                        offRampQuoteId: string;
+                    } | {
+                        /**
+                         * @description Intent kind for depositing USDC into a Kamino vault.
+                         * @constant
+                         */
+                        kind: "yield.deposit";
+                        /**
+                         * @description Yield protocol that will construct the deposit instructions. Only Kamino is supported for Solana yield transactions today.
+                         * @constant
+                         */
+                        protocol: "kamino";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        vault: string;
+                        /**
+                         * @description Positive integer amount in base units, formatted as a string. For native SOL this is lamports. For SPL tokens this is the mint's base unit, for example USDC uses 6 decimals.
+                         * @example 1000000
+                         */
+                        amount: string;
+                        /**
+                         * @description Solana USDC mint address supported by the selected Kamino vault.
+                         * @example EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+                         */
+                        mint: string;
+                    } | {
+                        /**
+                         * @description Intent kind for withdrawing from a Kamino vault.
+                         * @constant
+                         */
+                        kind: "yield.withdraw";
+                        /**
+                         * @description Yield protocol that will construct the withdraw instructions. Only Kamino is supported for Solana yield transactions today.
+                         * @constant
+                         */
+                        protocol: "kamino";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        vault: string;
+                        /**
+                         * @description Withdraw the user's full available position from this vault. Partial withdraws are not exposed by Wallet Kit yet.
+                         * @constant
+                         */
+                        withdrawAll: true;
+                        /**
+                         * @description Solana USDC mint address supported by the selected Kamino vault.
+                         * @example EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+                         */
+                        mint: string;
+                    };
+                };
+                "multipart/form-data": {
+                    /** @description Caller-supplied idempotency key for this prepare call. Repeating the same `clientIntentId` with an identical intent returns the existing prepared transaction while it is active. Reusing the same key with different intent details returns a conflict error. */
+                    clientIntentId: string;
+                    /**
+                     * @description Version of the intent schema. Production prepare currently expects exactly `1`.
+                     * @example 1
+                     * @constant
+                     */
+                    intentVersion: 1;
+                    /** @enum {string} */
+                    feeMode?: "auto" | "sponsored_only" | "user_paid_only";
+                    /** @description Discriminated Solana transaction intent. Use `transfer` for wallet transfers, `payment` for Spritz off-ramp quote payments, `yield.deposit` for Kamino USDC vault deposits, and `yield.withdraw` for Kamino USDC vault withdrawals. */
+                    intent: {
+                        /**
+                         * @description Intent kind for a native SOL or SPL token transfer.
+                         * @constant
+                         */
+                        kind: "transfer";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Recipient Solana public key (base58).
+                         * @example FqVnHphYBfJTb46iWbwS8oRaAWGnLPVhWqvY1pgZ7yC8
+                         */
+                        to: string;
+                        /**
+                         * @description Positive integer amount in base units, formatted as a string. For native SOL this is lamports. For SPL tokens this is the mint's base unit, for example USDC uses 6 decimals.
+                         * @example 1000000
+                         */
+                        amount: string;
+                        /**
+                         * @description SPL mint address for token transfers, or null for native SOL transfers.
+                         * @example null
+                         */
+                        mint: string | null;
+                    } | {
+                        /**
+                         * @description Intent kind for a Spritz off-ramp quote payment.
+                         * @constant
+                         */
+                        kind: "payment";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Existing off-ramp quote id. The transaction builder resolves amount due, destination, memo/reference, and token route from this quote.
+                         * @example offramp_xyz789
+                         */
+                        offRampQuoteId: string;
+                    } | {
+                        /**
+                         * @description Intent kind for depositing USDC into a Kamino vault.
+                         * @constant
+                         */
+                        kind: "yield.deposit";
+                        /**
+                         * @description Yield protocol that will construct the deposit instructions. Only Kamino is supported for Solana yield transactions today.
+                         * @constant
+                         */
+                        protocol: "kamino";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        vault: string;
+                        /**
+                         * @description Positive integer amount in base units, formatted as a string. For native SOL this is lamports. For SPL tokens this is the mint's base unit, for example USDC uses 6 decimals.
+                         * @example 1000000
+                         */
+                        amount: string;
+                        /**
+                         * @description Solana USDC mint address supported by the selected Kamino vault.
+                         * @example EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+                         */
+                        mint: string;
+                    } | {
+                        /**
+                         * @description Intent kind for withdrawing from a Kamino vault.
+                         * @constant
+                         */
+                        kind: "yield.withdraw";
+                        /**
+                         * @description Yield protocol that will construct the withdraw instructions. Only Kamino is supported for Solana yield transactions today.
+                         * @constant
+                         */
+                        protocol: "kamino";
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        from: string;
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        vault: string;
+                        /**
+                         * @description Withdraw the user's full available position from this vault. Partial withdraws are not exposed by Wallet Kit yet.
+                         * @constant
+                         */
+                        withdrawAll: true;
+                        /**
+                         * @description Solana USDC mint address supported by the selected Kamino vault.
+                         * @example EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+                         */
+                        mint: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Prepare response for the embedded-wallet signing flow. Decode `messageBytes`, sign those exact bytes with `userSigner`, then submit only the detached base64 signature. Do not submit a serialized transaction or rebuild the message client-side. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Server-issued transaction id. Pass this back to the submit endpoint along with the user signature. */
+                        txId: string;
+                        /** @description Base64-encoded Solana v0 message bytes. The embedded wallet must sign exactly these bytes after base64 decoding — do not mutate, rebuild, or wrap. */
+                        messageBytes: string;
+                        /**
+                         * @description Format of `messageBytes`. `solana_message_v0` means the bytes are a Solana v0 message, not a serialized transaction.
+                         * @constant
+                         */
+                        messageFormat: "solana_message_v0";
+                        /**
+                         * @description Solana public key that must produce `userSignature` over the decoded `messageBytes`.
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        userSigner: string;
+                        /** @description All signer public keys required by the prepared message. The embedded wallet is responsible for the `userSigner`; Spritz may add the fee-payer signature during submit. */
+                        requiredSigners: string[];
+                        /** @description Solana public key paying the network fee for the prepared transaction. */
+                        feePayer: string;
+                        /** @description Whether Spritz is expected to pay the Solana network fee for this prepared transaction. */
+                        sponsored: boolean;
+                        /**
+                         * @description Estimated Solana network fee in lamports for the prepared message.
+                         * @example 5000
+                         */
+                        estimatedFeeLamports: string | number;
+                        /** @description Address lookup table accounts used by the v0 message. Empty when the message does not use lookup tables. */
+                        addressLookupTableAddresses: string[];
+                        /** @description Recent blockhash embedded in the prepared message. This blockhash is what makes the prepared message expire. */
+                        blockhash: string;
+                        /** @description Last Solana block height at which the prepared message can still be submitted. */
+                        lastValidBlockHeight: string | number;
+                        /**
+                         * Format: date-time
+                         * @description ISO 8601 timestamp at which this prepared transaction expires. Solana blockhashes expire quickly; if submit fails with `TX_EXPIRED`, call prepare again and sign the new `messageBytes`.
+                         */
+                        expiresAt: string;
+                        /** @description Product summary of the prepared transaction. Shape varies by intent. Transfer summaries identify sender, recipient, mint, and amount. Payment summaries identify the off-ramp quote, destination, amount, mint, and required token input. Kamino yield summaries identify protocol, vault, mint, and the deposit amount or withdraw-all request. */
+                        summary: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 409 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 422 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 503 */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postV1Wallet-kitSolanaTransactionsSubmit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Request body for submitting the user's detached signature for a previously prepared Solana transaction. The server verifies this signature against the stored `messageBytes`, adds any Spritz-owned signatures such as the fee payer, serializes the final transaction, and broadcasts it. */
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Server transaction id returned by the prepare endpoint. */
+                    txId: string;
+                    /** @description Base64-encoded 64-byte ed25519 signature over the decoded `messageBytes` returned by prepare. Never send a fully signed transaction here — only the detached user signature. */
+                    userSignature: string;
+                };
+                "application/x-www-form-urlencoded": {
+                    /** @description Server transaction id returned by the prepare endpoint. */
+                    txId: string;
+                    /** @description Base64-encoded 64-byte ed25519 signature over the decoded `messageBytes` returned by prepare. Never send a fully signed transaction here — only the detached user signature. */
+                    userSignature: string;
+                };
+                "multipart/form-data": {
+                    /** @description Server transaction id returned by the prepare endpoint. */
+                    txId: string;
+                    /** @description Base64-encoded 64-byte ed25519 signature over the decoded `messageBytes` returned by prepare. Never send a fully signed transaction here — only the detached user signature. */
+                    userSignature: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Submit response. The transaction has been broadcast to the Solana cluster. If submit is retried after a successful broadcast, the existing signature is returned. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Server transaction id. */
+                        txId: string;
+                        /** @description Solana transaction signature (base58). */
+                        signature: string;
+                        /**
+                         * @description Role of the signature returned (e.g., `fee_payer`).
+                         * @example fee_payer
+                         */
+                        signatureRole: string;
+                        /**
+                         * @description Transaction status (e.g., `submitted`).
+                         * @example submitted
+                         */
+                        status: string;
+                        /** @description URL to view the transaction on a Solana explorer. */
+                        explorerUrl: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 409 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 422 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 503 */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postV1Wallet-kitSolanaTransactionsByTxIdSubmit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                txId: string;
+            };
+            cookie?: never;
+        };
+        /** @description Request body for the path-based submit alias. The `txId` comes from the URL path; the body contains only the user's detached signature. */
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Base64-encoded 64-byte ed25519 signature over the decoded `messageBytes` returned by prepare. Never send a fully signed transaction here - only the detached user signature. */
+                    userSignature: string;
+                };
+                "application/x-www-form-urlencoded": {
+                    /** @description Base64-encoded 64-byte ed25519 signature over the decoded `messageBytes` returned by prepare. Never send a fully signed transaction here - only the detached user signature. */
+                    userSignature: string;
+                };
+                "multipart/form-data": {
+                    /** @description Base64-encoded 64-byte ed25519 signature over the decoded `messageBytes` returned by prepare. Never send a fully signed transaction here - only the detached user signature. */
+                    userSignature: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Submit response. The transaction has been broadcast to the Solana cluster. If submit is retried after a successful broadcast, the existing signature is returned. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Server transaction id. */
+                        txId: string;
+                        /** @description Solana transaction signature (base58). */
+                        signature: string;
+                        /**
+                         * @description Role of the signature returned (e.g., `fee_payer`).
+                         * @example fee_payer
+                         */
+                        signatureRole: string;
+                        /**
+                         * @description Transaction status (e.g., `submitted`).
+                         * @example submitted
+                         */
+                        status: string;
+                        /** @description URL to view the transaction on a Solana explorer. */
+                        explorerUrl: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 409 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 422 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 503 */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitAuth-methods": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of the authenticated user's auth methods. Empty when no wallet has been provisioned. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Auth methods registered on the user's embedded wallet sub-organization. */
+                        data: {
+                            /** @description Stable identifier for the auth method. */
+                            id: string;
+                            /** @enum {string} */
+                            kind: "passkey" | "google" | "apple" | "email";
+                            /** @description Human-readable label for the method (e.g., the email address, OAuth account label, or passkey nickname). */
+                            label: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the method was added (ISO 8601).
+                             */
+                            addedAt: string;
+                            /** @description Whether this method is the user's primary method. The primary method cannot be removed without first promoting another. */
+                            isPrimary: boolean;
+                        }[];
+                        /**
+                         * @description Whether more results are available beyond `data`. Always false — the full list is returned in a single response.
+                         * @example false
+                         */
+                        hasMore: boolean;
+                        /** @description Opaque pagination cursor. Always null — the full list is returned in a single response. */
+                        nextCursor: string | null;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postV1Wallet-kitAuth-methods": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Commit body for any prepared auth-method activity (add, email-start, remove). */
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Intent identifier returned by the matching prepare call. */
+                    intentId: string;
+                    /** @description Turnkey stamp produced by signing the prepared `activityBody` with the user's WebAuthn authenticator. */
+                    stamp: string;
+                };
+                "application/x-www-form-urlencoded": {
+                    /** @description Intent identifier returned by the matching prepare call. */
+                    intentId: string;
+                    /** @description Turnkey stamp produced by signing the prepared `activityBody` with the user's WebAuthn authenticator. */
+                    stamp: string;
+                };
+                "multipart/form-data": {
+                    /** @description Intent identifier returned by the matching prepare call. */
+                    intentId: string;
+                    /** @description Turnkey stamp produced by signing the prepared `activityBody` with the user's WebAuthn authenticator. */
+                    stamp: string;
+                };
+            };
+        };
+        responses: {
+            /** @description The newly registered auth method. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description An authentication method registered on the user's embedded wallet sub-organization. */
+                        data: {
+                            /** @description Stable identifier for the auth method. */
+                            id: string;
+                            /** @enum {string} */
+                            kind: "passkey" | "google" | "apple" | "email";
+                            /** @description Human-readable label for the method (e.g., the email address, OAuth account label, or passkey nickname). */
+                            label: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the method was added (ISO 8601).
+                             */
+                            addedAt: string;
+                            /** @description Whether this method is the user's primary method. The primary method cannot be removed without first promoting another. */
+                            isPrimary: boolean;
+                        };
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 409 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postV1Wallet-kitAuth-methodsIntents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Prepare request for adding an auth method. Discriminated by `kind`. Email requires a prior call to the email-start flow to obtain `otpId`. */
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @constant */
+                    kind: "passkey";
+                    /** @description Passkey/WebAuthn challenge produced by the client SDK. */
+                    challenge: string;
+                    /** @description Optional nickname for this passkey. */
+                    label?: string;
+                } | {
+                    kind: "google" | "apple";
+                    /** @description OIDC ID token issued by Google or Apple after a successful sign-in flow on the client. */
+                    oidcToken: string;
+                    /** @description Optional label for this method. */
+                    label?: string;
+                } | {
+                    /** @constant */
+                    kind: "email";
+                    /**
+                     * Format: email
+                     * @description Email address to register. Must match the OTP start email.
+                     */
+                    email: string;
+                    /** @description One-time passcode delivered to `email` by the email-start flow. */
+                    otp: string;
+                    /** @description OTP identifier returned by the email-start commit endpoint. */
+                    otpId: string;
+                    /** @description Turnkey iframe public key produced by the client SDK (e.g. `authIframeClient.iframePublicKey`). */
+                    targetPublicKey: string;
+                    /** @description Optional label for this method. */
+                    label?: string;
+                };
+                "application/x-www-form-urlencoded": {
+                    /** @constant */
+                    kind: "passkey";
+                    /** @description Passkey/WebAuthn challenge produced by the client SDK. */
+                    challenge: string;
+                    /** @description Optional nickname for this passkey. */
+                    label?: string;
+                } | {
+                    kind: "google" | "apple";
+                    /** @description OIDC ID token issued by Google or Apple after a successful sign-in flow on the client. */
+                    oidcToken: string;
+                    /** @description Optional label for this method. */
+                    label?: string;
+                } | {
+                    /** @constant */
+                    kind: "email";
+                    /**
+                     * Format: email
+                     * @description Email address to register. Must match the OTP start email.
+                     */
+                    email: string;
+                    /** @description One-time passcode delivered to `email` by the email-start flow. */
+                    otp: string;
+                    /** @description OTP identifier returned by the email-start commit endpoint. */
+                    otpId: string;
+                    /** @description Turnkey iframe public key produced by the client SDK (e.g. `authIframeClient.iframePublicKey`). */
+                    targetPublicKey: string;
+                    /** @description Optional label for this method. */
+                    label?: string;
+                };
+                "multipart/form-data": {
+                    /** @constant */
+                    kind: "passkey";
+                    /** @description Passkey/WebAuthn challenge produced by the client SDK. */
+                    challenge: string;
+                    /** @description Optional nickname for this passkey. */
+                    label?: string;
+                } | {
+                    kind: "google" | "apple";
+                    /** @description OIDC ID token issued by Google or Apple after a successful sign-in flow on the client. */
+                    oidcToken: string;
+                    /** @description Optional label for this method. */
+                    label?: string;
+                } | {
+                    /** @constant */
+                    kind: "email";
+                    /**
+                     * Format: email
+                     * @description Email address to register. Must match the OTP start email.
+                     */
+                    email: string;
+                    /** @description One-time passcode delivered to `email` by the email-start flow. */
+                    otp: string;
+                    /** @description OTP identifier returned by the email-start commit endpoint. */
+                    otpId: string;
+                    /** @description Turnkey iframe public key produced by the client SDK (e.g. `authIframeClient.iframePublicKey`). */
+                    targetPublicKey: string;
+                    /** @description Optional label for this method. */
+                    label?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Prepare response. Branch on `status`: `intent_required` requires stamping + commit; `already_exists` returns the existing method directly. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        status: "intent_required";
+                        /** @description Prepared activity that the embedded wallet must stamp before commit. */
+                        intent: {
+                            /** @description Single-use intent identifier returned by prepare. Pass back to commit alongside the user's stamp. TTL is 60 seconds. */
+                            intentId: string;
+                            /** @description Turnkey activity body bytes for the wallet to stamp. Sign with the user's WebAuthn authenticator and submit the stamp via the matching commit endpoint. */
+                            activityBody: string;
+                            /** @description Unix-millisecond timestamp the activity body was issued at. Pass through verbatim when stamping. */
+                            timestampMs: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp at which the prepared intent expires (60s after issue).
+                             */
+                            expiresAt: string;
+                        };
+                    } | {
+                        /** @constant */
+                        status: "already_exists";
+                        /** @description An authentication method registered on the user's embedded wallet sub-organization. */
+                        data: {
+                            /** @description Stable identifier for the auth method. */
+                            id: string;
+                            /** @description Authentication method kind. `passkey` is a WebAuthn authenticator on this device; `google`/`apple` are OIDC tokens; `email` is a verified email address used for OTP login. */
+                            kind: "passkey" | "google" | "apple" | "email";
+                            /** @description Human-readable label for the method (e.g., the email address, OAuth account label, or passkey nickname). */
+                            label: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the method was added (ISO 8601).
+                             */
+                            addedAt: string;
+                            /** @description Whether this method is the user's primary method. The primary method cannot be removed without first promoting another. */
+                            isPrimary: boolean;
+                        };
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 409 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 429 */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postV1Wallet-kitAuth-methodsEmailStartIntents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Prepare body for starting the email-OTP flow. */
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: email
+                     * @description Email address to send the one-time passcode to.
+                     */
+                    email: string;
+                };
+                "application/x-www-form-urlencoded": {
+                    /**
+                     * Format: email
+                     * @description Email address to send the one-time passcode to.
+                     */
+                    email: string;
+                };
+                "multipart/form-data": {
+                    /**
+                     * Format: email
+                     * @description Email address to send the one-time passcode to.
+                     */
+                    email: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Prepared email-start activity. Stamp `intent.activityBody` and submit via the matching commit endpoint. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Prepared activity that the embedded wallet must stamp before commit. */
+                        intent: {
+                            /** @description Single-use intent identifier returned by prepare. Pass back to commit alongside the user's stamp. TTL is 60 seconds. */
+                            intentId: string;
+                            /** @description Turnkey activity body bytes for the wallet to stamp. Sign with the user's WebAuthn authenticator and submit the stamp via the matching commit endpoint. */
+                            activityBody: string;
+                            /** @description Unix-millisecond timestamp the activity body was issued at. Pass through verbatim when stamping. */
+                            timestampMs: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp at which the prepared intent expires (60s after issue).
+                             */
+                            expiresAt: string;
+                        };
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 429 */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postV1Wallet-kitAuth-methodsEmailStart": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Commit body for any prepared auth-method activity (add, email-start, remove). */
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Intent identifier returned by the matching prepare call. */
+                    intentId: string;
+                    /** @description Turnkey stamp produced by signing the prepared `activityBody` with the user's WebAuthn authenticator. */
+                    stamp: string;
+                };
+                "application/x-www-form-urlencoded": {
+                    /** @description Intent identifier returned by the matching prepare call. */
+                    intentId: string;
+                    /** @description Turnkey stamp produced by signing the prepared `activityBody` with the user's WebAuthn authenticator. */
+                    stamp: string;
+                };
+                "multipart/form-data": {
+                    /** @description Intent identifier returned by the matching prepare call. */
+                    intentId: string;
+                    /** @description Turnkey stamp produced by signing the prepared `activityBody` with the user's WebAuthn authenticator. */
+                    stamp: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Email-start commit response. The OTP has been dispatched. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /**
+                             * Format: email
+                             * @description Email the OTP was sent to.
+                             */
+                            email: string;
+                            /** @description OTP identifier to pass back to the add-auth-method prepare call along with the OTP. */
+                            otpId: string;
+                        };
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 409 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postV1Wallet-kitAuth-methodsByIdIntents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Prepared remove activity. Stamp `intent.activityBody` and submit via DELETE with the same `intentId`. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Prepared activity that the embedded wallet must stamp before commit. */
+                        intent: {
+                            /** @description Single-use intent identifier returned by prepare. Pass back to commit alongside the user's stamp. TTL is 60 seconds. */
+                            intentId: string;
+                            /** @description Turnkey activity body bytes for the wallet to stamp. Sign with the user's WebAuthn authenticator and submit the stamp via the matching commit endpoint. */
+                            activityBody: string;
+                            /** @description Unix-millisecond timestamp the activity body was issued at. Pass through verbatim when stamping. */
+                            timestampMs: string;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp at which the prepared intent expires (60s after issue).
+                             */
+                            expiresAt: string;
+                        };
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 404 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 409 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "deleteV1Wallet-kitAuth-methodsById": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Commit body for any prepared auth-method activity (add, email-start, remove). */
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Intent identifier returned by the matching prepare call. */
+                    intentId: string;
+                    /** @description Turnkey stamp produced by signing the prepared `activityBody` with the user's WebAuthn authenticator. */
+                    stamp: string;
+                };
+                "application/x-www-form-urlencoded": {
+                    /** @description Intent identifier returned by the matching prepare call. */
+                    intentId: string;
+                    /** @description Turnkey stamp produced by signing the prepared `activityBody` with the user's WebAuthn authenticator. */
+                    stamp: string;
+                };
+                "multipart/form-data": {
+                    /** @description Intent identifier returned by the matching prepare call. */
+                    intentId: string;
+                    /** @description Turnkey stamp produced by signing the prepared `activityBody` with the user's WebAuthn authenticator. */
+                    stamp: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Response for status 204 */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    type: unknown;
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 404 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 409 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitYieldSolanaKaminoVaults": {
+        parameters: {
+            query?: {
+                asset?: "USDC";
+                includeUnlisted?: "true" | "false";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated Kamino yield vault list. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /** @description Kamino vault identifier. */
+                            id: string;
+                            /** @constant */
+                            protocol: "kamino";
+                            /** @constant */
+                            chain: "solana";
+                            name: string;
+                            isListed: boolean;
+                            depositToken: {
+                                /** @enum {string} */
+                                symbol: "USDC" | "UNKNOWN";
+                                mint: string;
+                                decimals: string | number;
+                            };
+                            receiptToken: {
+                                mint: string;
+                                decimals: string | number;
+                            };
+                            apy: {
+                                current: string | null;
+                                actual: string | null;
+                                theoretical: string | null;
+                                apy24h: string | null;
+                                apy7d: string | null;
+                                apy30d: string | null;
+                                apy90d: string | null;
+                                apy180d: string | null;
+                                apy365d: string | null;
+                                farmRewards: string | null;
+                                incentives: string | null;
+                                reservesIncentives: string | null;
+                            };
+                            tvl: {
+                                tokenAmount: string | null;
+                                usdAmount: string | null;
+                            };
+                            liquidity: {
+                                availableTokenAmount: string | null;
+                                investedTokenAmount: string | null;
+                            };
+                            sharePrice: string | null;
+                            tokensPerShare: string | null;
+                            numberOfHolders: (string | number) | null;
+                            fees: {
+                                performanceFeeBps: string | number;
+                                managementFeeBps: string | number;
+                                withdrawalPenaltyBps: string | number;
+                            };
+                            limits: {
+                                minDepositAmount: string;
+                                minWithdrawAmount: string;
+                            };
+                            risk: {
+                                /** @enum {string} */
+                                level: "low" | "medium" | "high" | "unknown";
+                                labels: string[];
+                                whitelistedReservesOnly: boolean;
+                                whitelistedInvestOnly: boolean;
+                                hasFirstLossCapitalFarm: boolean;
+                                firstLossCapitalFarm: string | null;
+                            };
+                            allocations: {
+                                reserve: string;
+                                marketName: string | null;
+                                supplyApy: string | null;
+                                totalSupplyUsd: string | null;
+                                maxLtv: string | null;
+                            }[];
+                        }[];
+                        /**
+                         * @description Whether more results are available. Always false today.
+                         * @example false
+                         */
+                        hasMore: boolean;
+                        /** @description Opaque pagination cursor. Always null today. */
+                        nextCursor: string | null;
+                    };
+                };
+            };
+            /** @description Response for status 400 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitYieldSolanaKaminoVaultsByVaultId": {
+        parameters: {
+            query?: {
+                asset?: "USDC";
+                includeUnlisted?: "true" | "false";
+            };
+            header?: never;
+            path: {
+                vaultId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Kamino yield vault available through Wallet Kit. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Kamino vault identifier. */
+                        id: string;
+                        /** @constant */
+                        protocol: "kamino";
+                        /** @constant */
+                        chain: "solana";
+                        name: string;
+                        isListed: boolean;
+                        depositToken: {
+                            /** @enum {string} */
+                            symbol: "USDC" | "UNKNOWN";
+                            mint: string;
+                            decimals: string | number;
+                        };
+                        receiptToken: {
+                            mint: string;
+                            decimals: string | number;
+                        };
+                        apy: {
+                            current: string | null;
+                            actual: string | null;
+                            theoretical: string | null;
+                            apy24h: string | null;
+                            apy7d: string | null;
+                            apy30d: string | null;
+                            apy90d: string | null;
+                            apy180d: string | null;
+                            apy365d: string | null;
+                            farmRewards: string | null;
+                            incentives: string | null;
+                            reservesIncentives: string | null;
+                        };
+                        tvl: {
+                            tokenAmount: string | null;
+                            usdAmount: string | null;
+                        };
+                        liquidity: {
+                            availableTokenAmount: string | null;
+                            investedTokenAmount: string | null;
+                        };
+                        sharePrice: string | null;
+                        tokensPerShare: string | null;
+                        numberOfHolders: (string | number) | null;
+                        fees: {
+                            performanceFeeBps: string | number;
+                            managementFeeBps: string | number;
+                            withdrawalPenaltyBps: string | number;
+                        };
+                        limits: {
+                            minDepositAmount: string;
+                            minWithdrawAmount: string;
+                        };
+                        risk: {
+                            /** @enum {string} */
+                            level: "low" | "medium" | "high" | "unknown";
+                            labels: string[];
+                            whitelistedReservesOnly: boolean;
+                            whitelistedInvestOnly: boolean;
+                            hasFirstLossCapitalFarm: boolean;
+                            firstLossCapitalFarm: string | null;
+                        };
+                        allocations: {
+                            reserve: string;
+                            marketName: string | null;
+                            supplyApy: string | null;
+                            totalSupplyUsd: string | null;
+                            maxLtv: string | null;
+                        }[];
+                    };
+                };
+            };
+            /** @description Response for status 400 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 404 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitYieldSolanaKaminoVaultsByVaultIdHistory": {
+        parameters: {
+            query?: {
+                start?: string;
+                end?: string;
+            };
+            header?: never;
+            path: {
+                vaultId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated Kamino yield history. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            createdAt: string | null;
+                            tvlUsd: string | null;
+                            apy: string | null;
+                            cumulativeInterestEarnedUsd: string | null;
+                            /** @description Raw provider payload retained for diagnostics. */
+                            raw: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                        /**
+                         * @description Whether more results are available. Always false today.
+                         * @example false
+                         */
+                        hasMore: boolean;
+                        /** @description Opaque pagination cursor. Always null today. */
+                        nextCursor: string | null;
+                    };
+                };
+            };
+            /** @description Response for status 400 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 404 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitYieldSolanaKaminoPositions": {
+        parameters: {
+            query: {
+                walletAddress: string;
+                asset?: "USDC";
+                includeUnlisted?: "true" | "false";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated Kamino yield positions. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            vaultId: string;
+                            /**
+                             * @description Solana public key (base58).
+                             * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                             */
+                            walletAddress: string;
+                            vaultName: string | null;
+                            depositToken: {
+                                /** @enum {string} */
+                                symbol: "USDC" | "UNKNOWN";
+                                mint: string | null;
+                                decimals: (string | number) | null;
+                            };
+                            shares: {
+                                staked: string;
+                                unstaked: string;
+                                total: string;
+                            };
+                            value: {
+                                tokenAmount: string | null;
+                                usdAmount: string | null;
+                            };
+                            sharePrice: string | null;
+                            tokensPerShare: string | null;
+                            /** @description Raw provider payload retained for diagnostics. */
+                            raw: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                        /**
+                         * @description Whether more results are available. Always false today.
+                         * @example false
+                         */
+                        hasMore: boolean;
+                        /** @description Opaque pagination cursor. Always null today. */
+                        nextCursor: string | null;
+                    };
+                };
+            };
+            /** @description Response for status 400 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitYieldSolanaKaminoPositionsByVaultId": {
+        parameters: {
+            query: {
+                walletAddress: string;
+            };
+            header?: never;
+            path: {
+                vaultId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Kamino yield position lookup response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Kamino yield position, or null when Kamino reports no position. */
+                        data: {
+                            vaultId: string;
+                            /**
+                             * @description Solana public key (base58).
+                             * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                             */
+                            walletAddress: string;
+                            vaultName: string | null;
+                            depositToken: {
+                                symbol: "USDC" | "UNKNOWN";
+                                mint: string | null;
+                                decimals: (string | number) | null;
+                            };
+                            shares: {
+                                staked: string;
+                                unstaked: string;
+                                total: string;
+                            };
+                            value: {
+                                tokenAmount: string | null;
+                                usdAmount: string | null;
+                            };
+                            sharePrice: string | null;
+                            tokensPerShare: string | null;
+                            /** @description Raw provider payload retained for diagnostics. */
+                            raw: {
+                                [key: string]: unknown;
+                            };
+                        } | null;
+                    };
+                };
+            };
+            /** @description Response for status 400 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 404 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitYieldSolanaKaminoPositionsByVaultIdHistory": {
+        parameters: {
+            query: {
+                walletAddress: string;
+                start?: string;
+                end?: string;
+            };
+            header?: never;
+            path: {
+                vaultId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated Kamino yield history. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            createdAt: string | null;
+                            tvlUsd: string | null;
+                            apy: string | null;
+                            cumulativeInterestEarnedUsd: string | null;
+                            /** @description Raw provider payload retained for diagnostics. */
+                            raw: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                        /**
+                         * @description Whether more results are available. Always false today.
+                         * @example false
+                         */
+                        hasMore: boolean;
+                        /** @description Opaque pagination cursor. Always null today. */
+                        nextCursor: string | null;
+                    };
+                };
+            };
+            /** @description Response for status 400 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 404 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitYieldSolanaKaminoPositionsByVaultIdPnl": {
+        parameters: {
+            query: {
+                walletAddress: string;
+            };
+            header?: never;
+            path: {
+                vaultId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Kamino yield PnL for a wallet position. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        vaultId: string;
+                        /**
+                         * @description Solana public key (base58).
+                         * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                         */
+                        walletAddress: string;
+                        totalPnl: {
+                            usd: string;
+                            sol: string;
+                            token: string;
+                        };
+                        totalCostBasis: {
+                            usd: string;
+                            sol: string;
+                            token: string;
+                        };
+                    };
+                };
+            };
+            /** @description Response for status 400 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 404 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getV1Wallet-kitYieldSolanaKaminoTransactions": {
+        parameters: {
+            query: {
+                walletAddress: string;
+                vaultId?: string;
+                asset?: "USDC";
+                includeUnlisted?: "true" | "false";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated Kamino yield transactions. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            id: string | null;
+                            /**
+                             * @description Solana public key (base58).
+                             * @example 8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj
+                             */
+                            walletAddress: string;
+                            vaultId: string | null;
+                            kind: string | null;
+                            signature: string | null;
+                            createdAt: string | null;
+                            tokenMint: string | null;
+                            tokenAmount: string | null;
+                            tokenPrice: string | null;
+                            solPrice: string | null;
+                            sharePrice: string | null;
+                            numberOfShares: string | null;
+                            usdValue: string | null;
+                            latestPosition: boolean | null;
+                            /** @description Raw provider payload retained for diagnostics. */
+                            raw: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                        /**
+                         * @description Whether more results are available. Always false today.
+                         * @example false
+                         */
+                        hasMore: boolean;
+                        /** @description Opaque pagination cursor. Always null today. */
+                        nextCursor: string | null;
+                    };
+                };
+            };
+            /** @description Response for status 400 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 401 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:auth:token-expired
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Token Expired
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 401
+                         * @example 403
+                         */
+                        status: number;
+                        /**
+                         * @description A human-readable explanation specific to this occurrence
+                         * @example Bearer token required
+                         * @example Invalid token
+                         */
+                        detail?: string;
+                        /** @description A URI reference that identifies the specific occurrence */
+                        instance?: string;
+                        /**
+                         * @description The authentication realm
+                         * @example API
+                         */
+                        realm?: string;
+                        /**
+                         * @description The required scope for this resource
+                         * @example read:users
+                         * @example write:orders
+                         */
+                        scope?: string;
+                    };
+                };
+            };
+            /** @description Response for status 500 */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A URI reference that identifies the problem type
+                         * @default about:blank
+                         * @example urn:problem-type:auth:unauthorized
+                         * @example urn:problem-type:system:internal-error
+                         */
+                        type: string;
+                        /**
+                         * @description A short, human-readable summary of the problem type
+                         * @example Unauthorized
+                         * @example Internal Server Error
+                         */
+                        title: string;
+                        /**
+                         * @description The HTTP status code
+                         * @example 400
+                         * @example 401
+                         * @example 404
+                         * @example 500
+                         */
+                        status: number;
+                        /** @description A human-readable explanation specific to this occurrence */
+                        detail?: string;
+                        /**
+                         * @description A URI reference that identifies the specific occurrence
+                         * @example /errors/1234567890
+                         */
+                        instance?: string;
+                    };
+                };
+            };
+            /** @description Response for status 502 */
+            502: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
- Add SDK-backed QC evidence flow for ACH debit release, including sandbox return simulation and redacted evidence output
- Introduce typed webhook subscription updates via `client.webhook.update(webhookId, { events })`, adding support for onramp and ACH debit return events plus `'*'` (subscribe to all)
- Align `WebhookService` request/response types and endpoints with the REST API and update webhook docs/signature verification guidance
- Prefer RFC 7807 `title`/`detail` fields when constructing `APIError` messages for clearer partner-facing errors
- Add funding source deposit limits API (`client.fundingSource.getDepositLimits`) and document how limits/risk checks affect the ACH onramp flow
- Revert `client.bankAccount.list()` to the GraphQL `UserBankAccounts` query to preserve the existing response contract (REST payload omitted key fields)
- Add/clarify ACH onramp docs and include an ACH debit release QC plan