### PR TITLE
Clarify maintenance-publish dist-tag input

### DIFF
--- a/.changeset/maintenance-publish-dist-tag-docs.md
+++ b/.changeset/maintenance-publish-dist-tag-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clarify the maintenance-publish workflow's `dist-tag` input: npm rejects values that parse as SemVer ranges (e.g. `0.7`, `0.7.x`), so use a non-range form like `legacy-0.7`.

--- a/.github/workflows/maintenance-publish.yml
+++ b/.github/workflows/maintenance-publish.yml
@@ -7,7 +7,10 @@ on:
                 description: Maintenance branch (e.g. release/0.7) or commit SHA to publish from
                 required: true
             dist-tag:
-                description: npm dist-tag (e.g. 0.7, 0.8). Must NOT be 'latest' — use the main Publish workflow for that.
+                description: |
+                    npm dist-tag for this maintenance line (e.g. legacy-0.7, legacy-0.8). Must NOT be 'latest'
+                    (use the main Publish workflow for that) and must NOT parse as a SemVer range — that
+                    rules out bare versions like '0.7' or '0.7.x'. Prefix or suffix to avoid the SemVer parser.
                 required: true
 
 env:


### PR DESCRIPTION
## Summary
- npm rejected `0.7` as a dist-tag in the first maintenance run (parses as a SemVer range).
- Update the workflow's `dist-tag` input description to call this out and suggest `legacy-0.7` form.

## Test plan
- [ ] CI green
- [ ] Re-run Maintenance Publish with `dist-tag=legacy-0.7` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)