### PR TITLE
Document maintenance release workflow

### DIFF
--- a/.changeset/docs-maintenance-release-workflow.md
+++ b/.changeset/docs-maintenance-release-workflow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs-only: document the maintenance release workflow (diverged minor branches) in CLAUDE.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,51 @@
 - Merging a PR with `.changeset/*.md` files triggers the Release workflow, which opens a "Version Packages" PR automatically. Merging _that_ PR triggers the Publish workflow (runs in the `production` environment).
 - The repo's enterprise policy keeps `GITHUB_TOKEN` read-only. Set `CHANGESETS_GITHUB_TOKEN` in repo secrets so the release workflow can open the automated release PR.
 
+## Maintenance releases (diverged version chains)
+
+When `main` ships a breaking change but we still need to patch an older minor (e.g. a customer is pinned to `0.7.x` and won't upgrade), publish from a long-lived maintenance branch instead of forking the whole release process.
+
+### When to cut a maintenance branch
+
+- A breaking change is about to land on `main` AND at least one consumer can't upgrade soon.
+- Cut the branch _before_ merging the breaking change, from the last commit of the soon-to-be-old minor (the `Version Packages` merge commit for that version is the canonical fork point).
+
+### Branch naming
+
+- `release/0.7`, `release/0.8`, … — one branch per maintained minor.
+- Push to origin so CI and other engineers can use it.
+
+### Authoring a patch on a maintenance branch
+
+1. Check out `release/0.X`, branch off, apply the fix.
+2. **Hand-bump `package.json`** (`0.7.1` → `0.7.2`). Maintenance branches do NOT use changesets — changesets' `baseBranch` is `main` and trying to share its machinery across branches breaks. `package.json` is the source of truth here.
+3. No `.changeset/*.md` file. CHANGELOG can be hand-edited if you want a record (optional).
+4. PR against `release/0.X`, get review, merge.
+
+### Publishing
+
+Trigger the `Maintenance Publish` workflow manually:
+
+```
+gh workflow run maintenance-publish.yml --ref main \
+  -f ref=release/0.7 \
+  -f dist-tag=legacy-0.7
+```
+
+- `--ref main` is correct — `workflow_dispatch` reads the workflow file from the default branch, then checks out `inputs.ref` for the build.
+- **`dist-tag` must not be `latest`** (use the main Publish workflow for that) and **must not parse as a SemVer range** — `0.7`, `0.7.x`, `~0.7` all get rejected by npm. Use `legacy-0.7` or similar.
+- Consumers pin via `npm install @spritz-finance/api-client@legacy-0.7`.
+
+### One-time setup per maintained minor
+
+Before the first maintenance publish for a given minor, the `maintenance-publish.yml` workflow file path must be added to the npm trusted-publishing allowlist for `@spritz-finance/api-client`:
+
+- Repository: `spritz-finance/api-client`
+- Workflow filename: `maintenance-publish.yml`
+- Environment: `production`
+
+This is in addition to the existing entry for `publish.yml`. Without it, the workflow build succeeds but `npm publish` 404s.
+
 ## Testing
 
 - Uses Vitest for testing


### PR DESCRIPTION
## Summary
- Add a CLAUDE.md section covering the diverged-minor publishing flow we just set up: when to cut `release/0.X`, manual versioning (no changesets), triggering Maintenance Publish, the dist-tag SemVer-range gotcha, and the one-time npm trusted-publishing allowlist step.

## Test plan
- [ ] CI green (docs-only, no runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)