### PR TITLE
[codex] Centralize typed REST route handling

### DIFF
--- a/.changeset/typed-rest-route-handling.md
+++ b/.changeset/typed-rest-route-handling.md
@@ -1,0 +1,5 @@
+---
+'@spritz-finance/api-client': patch
+---
+
+Centralize typed REST route construction so SDK modules share path parameter encoding, query serialization, and generated OpenAPI response inference without changing public method behavior.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,163 @@
+# Improvements
+
+Architecture deepening backlog for `@spritz-finance/api-client`.
+
+Rules for every item:
+
+- [ ] No breaking public SDK changes.
+- [ ] Keep existing public methods unless explicitly superseded later.
+- [ ] Prefer additive modules and compatibility wrappers.
+- [ ] Ship small, reviewable diffs with focused tests.
+- [ ] Preserve generated GraphQL/OpenAPI type contracts.
+
+Selected next: **2. Deepen REST route handling**.
+
+## 1. Deepen Session Credentials
+
+Files:
+
+- `src/spritzApiClient.ts`
+- `src/lib/client.ts`
+- `src/modules/**`
+
+Problem:
+
+The root client currently mixes integrator credentials and user API key state. `setApiKey()` rebuilds modules, so retained module references can keep stale credentials. That is risky for backend integrators handling many users.
+
+Target:
+
+Make the root client integrator-scoped and add a user-scoped view without removing existing behavior.
+
+Checklist:
+
+- [ ] Add a session/request-context module that owns environment, integrator key, integrator secret, and optional user API key.
+- [ ] Add `client.forUser(apiKey)` as the preferred non-breaking interface for user-scoped calls.
+- [ ] Keep `client.setApiKey(apiKey)` working as a compatibility path.
+- [ ] Do not require `{ apiKey }` on every user method.
+- [ ] Ensure root integrator calls still work without a user API key.
+- [ ] Ensure user-scoped calls include the bearer token and shared integrator credentials.
+- [ ] Add tests for `forUser()` isolation across two user API keys.
+- [ ] Add tests covering retained module references after `setApiKey()`.
+- [ ] Update README examples after the implementation is stable.
+
+## 2. Deepen REST Route Handling
+
+Files:
+
+- `src/rest/types.ts`
+- `src/lib/client.ts`
+- `src/modules/bankAccount/bankAccountService.ts`
+- `src/modules/fundingSource/fundingSourceService.ts`
+- `src/modules/deposit/depositService.ts`
+- `src/modules/onrampPayment/onrampPaymentService.ts`
+- `src/modules/achDebitReturn/achDebitReturnService.ts`
+- `src/modules/webhook/webhookService.ts`
+- `src/modules/sandbox/sandboxService.ts`
+
+Problem:
+
+REST modules repeat method/path/body/query plumbing. Path literals are duplicated in value space and type space, path params are encoded by hand, and some query calls need casts. These modules are shallow: callers get little leverage from each interface, and route correctness has poor locality.
+
+Target:
+
+Create a typed REST route module that concentrates method, path params, query serialization, body typing, and response typing behind one seam.
+
+Checklist:
+
+- [ ] Add a typed route builder module for OpenAPI paths.
+- [ ] Centralize path param encoding.
+- [ ] Centralize query serialization while preserving current scalar behavior.
+- [ ] Bind `PathResponse`, `PathRequestBody`, `PathQuery`, and `PathParams` to one operation descriptor.
+- [ ] Keep `SpritzClient.restApi()` public/internal behavior compatible.
+- [ ] Migrate one low-risk module first, likely ACH debit returns or funding sources.
+- [ ] Add route builder tests for path params, query params, body passthrough, and response typing.
+- [ ] Migrate remaining REST modules in small follow-up diffs.
+- [ ] Delete repeated `encodeURIComponent` route assembly after migration.
+- [ ] Keep public module method names and return shapes unchanged.
+
+## 3. Deepen ACH Onramp Flow
+
+Files:
+
+- `docs/ach-onramp-guide.md`
+- `src/modules/bankAccount/bankAccountService.ts`
+- `src/modules/fundingSource/fundingSourceService.ts`
+- `src/modules/deposit/depositService.ts`
+- `src/modules/onrampPayment/onrampPaymentService.ts`
+- `src/modules/achDebitReturn/achDebitReturnService.ts`
+- `src/modules/webhook/webhookService.ts`
+
+Problem:
+
+The ACH onramp sequence is documented but not represented as a deep module. Integrators must know how bank accounts, funding sources, limits, deposit preparation, authorization text, deposit creation, webhooks, on-ramp payments, and ACH debit returns fit together.
+
+Target:
+
+Add an additive ACH onramp workflow module that concentrates eligibility and lifecycle rules while keeping existing primitive methods.
+
+Checklist:
+
+- [ ] Name the domain concept clearly before adding the module.
+- [ ] Keep existing bank account, funding source, deposit, webhook, and return methods unchanged.
+- [ ] Add helper methods only where they hide real ACH sequencing complexity.
+- [ ] Encode funding source eligibility checks in one place.
+- [ ] Encode active funding source readiness in one place.
+- [ ] Preserve caller control over displaying authorization text before deposit creation.
+- [ ] Add tests for happy path, ineligible account, pending source, inactive source, and exhausted limits.
+- [ ] Update docs to show the higher-leverage path while retaining primitive examples.
+
+## 4. Deepen User Access Policy
+
+Files:
+
+- `src/modules/user/userService.ts`
+- `src/modules/user/accessTransform.ts`
+- `src/modules/user/accessTypes.ts`
+- `src/modules/user/transform.ts`
+
+Problem:
+
+KYC, country support, Bridge user state, terms acceptance, and next-requirement ordering are real access policy. Today that policy lives as private transform helpers and has no focused test surface.
+
+Target:
+
+Make user access policy a named module with fixture-driven tests.
+
+Checklist:
+
+- [ ] Extract access policy into a module with one clear interface.
+- [ ] Keep `client.user.getUserAccess()` return shape unchanged.
+- [ ] Add fixtures for platform KYC states.
+- [ ] Add fixtures for Bridge user states.
+- [ ] Add fixtures for terms acceptance states.
+- [ ] Add country feature-map tests for onramp and offramp.
+- [ ] Add next-requirement ordering tests.
+- [ ] Keep transform code thin after policy extraction.
+
+## 5. Deepen Error And Fallback Behavior
+
+Files:
+
+- `src/lib/error.ts`
+- `src/lib/client.ts`
+- `src/modules/payment/paymentService.ts`
+- `src/modules/webhook/webhookService.ts`
+
+Problem:
+
+HTTP errors are well-shaped, GraphQL errors use a separate path, and some module methods silently convert failures into `null` or placeholder objects. That makes failure semantics part of individual module implementations instead of a shared interface.
+
+Target:
+
+Concentrate SDK error and fallback semantics so callers get consistent behavior and maintainers get locality.
+
+Checklist:
+
+- [ ] Define when `null` means not found versus request failure.
+- [ ] Define when a fallback object is acceptable.
+- [ ] Align GraphQL error behavior with HTTP error behavior where possible.
+- [ ] Preserve exported error classes and current throw behavior unless adding a compatibility layer.
+- [ ] Add tests for GraphQL errors with request headers.
+- [ ] Add tests for REST RFC 7807 errors.
+- [ ] Add tests for module-level nullable lookups.
+- [ ] Remove silent catches that hide actionable failures unless they are part of the documented interface.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -10,7 +10,7 @@ Rules for every item:
 - [ ] Ship small, reviewable diffs with focused tests.
 - [ ] Preserve generated GraphQL/OpenAPI type contracts.
 
-Selected next: **2. Deepen REST route handling**.
+Completed first: **2. Deepen REST route handling**.
 
 ## 1. Deepen Session Credentials
 
@@ -64,16 +64,16 @@ Create a typed REST route module that concentrates method, path params, query se
 
 Checklist:
 
-- [ ] Add a typed route builder module for OpenAPI paths.
-- [ ] Centralize path param encoding.
-- [ ] Centralize query serialization while preserving current scalar behavior.
-- [ ] Bind `PathResponse`, `PathRequestBody`, `PathQuery`, and `PathParams` to one operation descriptor.
-- [ ] Keep `SpritzClient.restApi()` public/internal behavior compatible.
-- [ ] Migrate one low-risk module first, likely ACH debit returns or funding sources.
-- [ ] Add route builder tests for path params, query params, body passthrough, and response typing.
-- [ ] Migrate remaining REST modules in small follow-up diffs.
-- [ ] Delete repeated `encodeURIComponent` route assembly after migration.
-- [ ] Keep public module method names and return shapes unchanged.
+- [x] Add a typed route builder module for OpenAPI paths.
+- [x] Centralize path param encoding.
+- [x] Centralize query serialization while preserving current scalar behavior.
+- [x] Bind `PathResponse`, `PathRequestBody`, `PathQuery`, and `PathParams` to one operation descriptor.
+- [x] Keep `SpritzClient.restApi()` public/internal behavior compatible.
+- [x] Migrate one low-risk module first, likely ACH debit returns or funding sources.
+- [x] Add route builder tests for path params, query params, body passthrough, and response typing.
+- [x] Migrate remaining REST modules in small follow-up diffs.
+- [x] Delete repeated `encodeURIComponent` route assembly after migration.
+- [x] Keep public module method names and return shapes unchanged.
 
 ## 3. Deepen ACH Onramp Flow
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -7,6 +7,8 @@ import { APIConnectionError, APIConnectionTimeoutError, APIError, SpritzApiError
 import { gracefulParseJSON } from '../utils/json'
 import { validateGraphQLQuery, sanitizeGraphQLVariables } from '../utils/graphqlSecurity'
 import { stampRequest } from './hmac'
+import type { RestQuery, RestRoute } from '../rest/route'
+import type { HttpMethod, PathResponse, RestMethod, RestPath } from '../rest/types'
 
 type GraphQLVariables = Record<string, unknown>
 
@@ -25,8 +27,6 @@ type GraphQLResponseData<T> = {
     data: T
     errors?: { message: string }[] | null
 }
-
-type HTTPMethod = 'get' | 'post' | 'put' | 'patch' | 'delete'
 
 async function parseAPIResponse<Response>(
     props: APIResponseProps
@@ -106,7 +106,7 @@ export class SpritzClient {
         path,
         body = undefined,
     }: {
-        method: HTTPMethod
+        method: HttpMethod
         path: string
         body?: Request | undefined
     }) {
@@ -119,16 +119,30 @@ export class SpritzClient {
             .then(({ response }) => response)
     }
 
-    public async restApi<Response, Request extends GraphQLVariables = GraphQLVariables>({
+    public async restApi<P extends RestPath, M extends RestMethod<P>>(
+        route: RestRoute<P, M>
+    ): Promise<PathResponse<P, M>>
+    public async restApi<Response, Request = unknown>({
+        method,
+        path,
+        body,
+        query,
+    }: {
+        method: HttpMethod
+        path: string
+        body?: Request | undefined
+        query?: RestQuery
+    }): Promise<Response>
+    public async restApi<Response, Request = unknown>({
         method,
         path,
         body = undefined,
         query,
     }: {
-        method: HTTPMethod
+        method: HttpMethod
         path: string
         body?: Request | undefined
-        query?: Record<string, string | number | boolean | undefined>
+        query?: RestQuery
     }) {
         return this.sendRestApiRequest({
             method,
@@ -156,7 +170,7 @@ export class SpritzClient {
         path,
         body,
     }: {
-        method: HTTPMethod
+        method: HttpMethod
         path: string
         body: GraphQLVariables | undefined
     }) {
@@ -170,10 +184,10 @@ export class SpritzClient {
         body,
         query,
     }: {
-        method: HTTPMethod
+        method: HttpMethod
         path: string
-        body: GraphQLVariables | undefined
-        query?: Record<string, string | number | boolean | undefined>
+        body: unknown | undefined
+        query?: RestQuery
     }) {
         const { url, req, timeout } = this.buildRestRequest(
             method,
@@ -298,11 +312,11 @@ export class SpritzClient {
     }
 
     private buildRestRequest(
-        method: HTTPMethod,
+        method: HttpMethod,
         path: string,
-        reqBody?: GraphQLVariables | null,
+        reqBody?: unknown | null,
         baseURL?: string,
-        query?: Record<string, string | number | boolean | undefined>
+        query?: RestQuery
     ) {
         const body = reqBody ? JSON.stringify(reqBody) : null
         const contentLength = this.calculateContentLength(body)

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -148,7 +148,7 @@ export class SpritzClient {
             method,
             path,
             body,
-            query,
+            ...(query ? { query } : {}),
         })
             .then((res) => parseAPIResponse<Response>(res))
             .then(({ response }) => response)

--- a/src/modules/achDebitReturn/achDebitReturnService.ts
+++ b/src/modules/achDebitReturn/achDebitReturnService.ts
@@ -1,4 +1,5 @@
 import { SpritzClient } from '../../lib/client'
+import { restRoute } from '../../rest/route'
 import type { PathQuery, PathResponse } from '../../rest/types'
 
 export type AchDebitReturnListResponse = PathResponse<'/v1/integrator/ach-debit/returns', 'get'>
@@ -13,17 +14,16 @@ export class AchDebitReturnService {
     }
 
     public async list(query?: AchDebitReturnListQuery) {
-        return this.client.restApi<AchDebitReturnListResponse>({
-            method: 'get',
-            path: '/v1/integrator/ach-debit/returns',
-            query: query as Record<string, string | number | boolean | undefined>,
-        })
+        return this.client.restApi(
+            restRoute('/v1/integrator/ach-debit/returns', 'get', query ? { query } : undefined)
+        )
     }
 
     public async get(returnId: string) {
-        return this.client.restApi<AchDebitReturn>({
-            method: 'get',
-            path: `/v1/integrator/ach-debit/returns/${encodeURIComponent(returnId)}`,
-        })
+        return this.client.restApi(
+            restRoute('/v1/integrator/ach-debit/returns/{returnId}', 'get', {
+                params: { returnId },
+            })
+        )
     }
 }

--- a/src/modules/bankAccount/bankAccountService.ts
+++ b/src/modules/bankAccount/bankAccountService.ts
@@ -1,4 +1,5 @@
 import { SpritzClient } from '../../lib/client'
+import { restRoute } from '../../rest/route'
 import type { PathRequestBody, PathResponse } from '../../rest/types'
 
 export type BankAccount = PathResponse<'/v1/bank-accounts/', 'get'>[number]
@@ -19,47 +20,44 @@ export class BankAccountService {
     }
 
     public async list() {
-        return this.client.restApi<BankAccountList>({
-            method: 'get',
-            path: '/v1/bank-accounts/',
-        })
+        return this.client.restApi(restRoute('/v1/bank-accounts/', 'get'))
     }
 
     public async get(accountId: string) {
-        return this.client.restApi<BankAccount>({
-            method: 'get',
-            path: `/v1/bank-accounts/${encodeURIComponent(accountId)}`,
-        })
+        return this.client.restApi(
+            restRoute('/v1/bank-accounts/{accountId}', 'get', {
+                params: { accountId },
+            })
+        )
     }
 
     public async create(input: CreateBankAccountInput) {
-        return this.client.restApi<CreateBankAccountResponse, CreateBankAccountInput>({
-            method: 'post',
-            path: '/v1/bank-accounts/',
-            body: input,
-        })
+        return this.client.restApi(
+            restRoute('/v1/bank-accounts/', 'post', {
+                body: input,
+            })
+        )
     }
 
     public async delete(accountId: string) {
-        return this.client.restApi<DeleteBankAccountResponse>({
-            method: 'delete',
-            path: `/v1/bank-accounts/${encodeURIComponent(accountId)}`,
-        })
+        return this.client.restApi(
+            restRoute('/v1/bank-accounts/{accountId}', 'delete', {
+                params: { accountId },
+            })
+        )
     }
 
     public async createLinkToken(input?: CreateLinkTokenRequest) {
-        return this.client.restApi<LinkTokenResponse, CreateLinkTokenRequest>({
-            method: 'post',
-            path: '/v1/bank-accounts/link-token',
-            body: input,
-        })
+        return this.client.restApi(
+            restRoute('/v1/bank-accounts/link-token', 'post', input ? { body: input } : undefined)
+        )
     }
 
     public async completeLinking(input: CompleteLinkingRequest) {
-        return this.client.restApi<CompleteLinkingResponse, CompleteLinkingRequest>({
-            method: 'post',
-            path: '/v1/bank-accounts/link-complete',
-            body: input,
-        })
+        return this.client.restApi(
+            restRoute('/v1/bank-accounts/link-complete', 'post', {
+                body: input,
+            })
+        )
     }
 }

--- a/src/modules/deposit/depositService.ts
+++ b/src/modules/deposit/depositService.ts
@@ -1,4 +1,5 @@
 import { SpritzClient } from '../../lib/client'
+import { restRoute } from '../../rest/route'
 import type { PathRequestBody, PathResponse } from '../../rest/types'
 
 export type PrepareDepositRequest = PathRequestBody<'/v1/deposits/direct/prepare', 'post'>
@@ -14,18 +15,18 @@ export class DepositService {
     }
 
     public async prepare(input: PrepareDepositRequest) {
-        return this.client.restApi<PrepareDepositResponse, PrepareDepositRequest>({
-            method: 'post',
-            path: '/v1/deposits/direct/prepare',
-            body: input,
-        })
+        return this.client.restApi(
+            restRoute('/v1/deposits/direct/prepare', 'post', {
+                body: input,
+            })
+        )
     }
 
     public async create(input: CreateDepositRequest) {
-        return this.client.restApi<Deposit, CreateDepositRequest>({
-            method: 'post',
-            path: '/v1/deposits/direct',
-            body: input,
-        })
+        return this.client.restApi(
+            restRoute('/v1/deposits/direct', 'post', {
+                body: input,
+            })
+        )
     }
 }

--- a/src/modules/fundingSource/fundingSourceService.ts
+++ b/src/modules/fundingSource/fundingSourceService.ts
@@ -1,4 +1,5 @@
 import { SpritzClient } from '../../lib/client'
+import { restRoute } from '../../rest/route'
 import type { PathResponse } from '../../rest/types'
 
 export type FundingSource = PathResponse<'/v1/funding-sources/', 'get'>[number]
@@ -15,23 +16,22 @@ export class FundingSourceService {
     }
 
     public async list() {
-        return this.client.restApi<PathResponse<'/v1/funding-sources/', 'get'>>({
-            method: 'get',
-            path: '/v1/funding-sources/',
-        })
+        return this.client.restApi(restRoute('/v1/funding-sources/', 'get'))
     }
 
     public async get(fundingSourceId: string) {
-        return this.client.restApi<PathResponse<'/v1/funding-sources/{fundingSourceId}', 'get'>>({
-            method: 'get',
-            path: `/v1/funding-sources/${encodeURIComponent(fundingSourceId)}`,
-        })
+        return this.client.restApi(
+            restRoute('/v1/funding-sources/{fundingSourceId}', 'get', {
+                params: { fundingSourceId },
+            })
+        )
     }
 
     public async getDepositLimits(fundingSourceId: string) {
-        return this.client.restApi<FundingSourceDepositLimits>({
-            method: 'get',
-            path: `/v1/funding-sources/${encodeURIComponent(fundingSourceId)}/deposit-limits`,
-        })
+        return this.client.restApi(
+            restRoute('/v1/funding-sources/{fundingSourceId}/deposit-limits', 'get', {
+                params: { fundingSourceId },
+            })
+        )
     }
 }

--- a/src/modules/onrampPayment/onrampPaymentService.ts
+++ b/src/modules/onrampPayment/onrampPaymentService.ts
@@ -1,6 +1,7 @@
 import CreateOnrampPaymentMutation from '../../graph/mutations/createOnrampPayment.graphql'
 import { SpritzClient } from '../../lib/client'
 import { CreateOnrampPaymentInput } from '../../types/globalTypes'
+import { restRoute } from '../../rest/route'
 import {
     CreateOnrampPayment,
     CreateOnrampPaymentVariables,
@@ -33,17 +34,14 @@ export class OnrampPaymentService {
     }
 
     public async list(query?: OnRampListQuery) {
-        return this.client.restApi<OnRampListResponse>({
-            method: 'get',
-            path: '/v1/on-ramps/',
-            query: query as Record<string, string | number | boolean | undefined>,
-        })
+        return this.client.restApi(restRoute('/v1/on-ramps/', 'get', query ? { query } : undefined))
     }
 
     public async get(onRampId: string) {
-        return this.client.restApi<OnRampDetail>({
-            method: 'get',
-            path: `/v1/on-ramps/${encodeURIComponent(onRampId)}`,
-        })
+        return this.client.restApi(
+            restRoute('/v1/on-ramps/{onRampId}', 'get', {
+                params: { onRampId },
+            })
+        )
     }
 }

--- a/src/modules/payment/paymentService.ts
+++ b/src/modules/payment/paymentService.ts
@@ -10,9 +10,7 @@ import PaymentRequestPaymentQuery from '../../graph/queries/paymentForPaymentReq
 import AccountPaymentsQuery from '../../graph/queries/paymentsForAccount.graphql'
 import PaymentQuery from '../../graph/queries/payment.graphql'
 import { SpritzClient } from '../../lib/client'
-import type { PathResponse } from '../../rest/types'
-
-type PaymentLimitsRaw = PathResponse<'/v1/bank-accounts/{accountId}/payment-limits', 'get'>
+import { restRoute } from '../../rest/route'
 
 export interface PaymentLimitsResponse {
     perTransaction: number
@@ -65,10 +63,11 @@ export class PaymentService {
 
     public async getPaymentLimits(accountId: string): Promise<PaymentLimitsResponse | null> {
         try {
-            const raw = await this.client.restApi<PaymentLimitsRaw>({
-                method: 'get',
-                path: `/v1/bank-accounts/${encodeURIComponent(accountId)}/payment-limits`,
-            })
+            const raw = await this.client.restApi(
+                restRoute('/v1/bank-accounts/{accountId}/payment-limits', 'get', {
+                    params: { accountId },
+                })
+            )
 
             return {
                 perTransaction: Number(raw.transactionLimit),

--- a/src/modules/sandbox/sandboxService.ts
+++ b/src/modules/sandbox/sandboxService.ts
@@ -1,4 +1,5 @@
 import { SpritzClient } from '../../lib/client'
+import { restRoute } from '../../rest/route'
 import type { PathRequestBody, PathResponse } from '../../rest/types'
 
 export type BypassKycRequest = PathRequestBody<'/v1/sandbox/bypass-kyc', 'post'>
@@ -17,11 +18,11 @@ export class SandboxService {
      * Only available in sandbox environments — returns 403 in production.
      */
     public async bypassKyc(options?: BypassKycRequest) {
-        return this.client.restApi({
-            method: 'post',
-            path: '/v1/sandbox/bypass-kyc',
-            body: options ?? { country: 'US' },
-        })
+        return this.client.restApi(
+            restRoute('/v1/sandbox/bypass-kyc', 'post', {
+                body: options ?? { country: 'US' },
+            })
+        )
     }
 
     /**
@@ -32,12 +33,10 @@ export class SandboxService {
      * Only available in sandbox environments — returns 403 in production.
      */
     public async createDepositWithReturn(input: CreateDepositWithReturnRequest) {
-        return this.client.restApi<CreateDepositWithReturnResponse, CreateDepositWithReturnRequest>(
-            {
-                method: 'post',
-                path: '/v1/sandbox/deposits/direct',
+        return this.client.restApi(
+            restRoute('/v1/sandbox/deposits/direct', 'post', {
                 body: input,
-            }
+            })
         )
     }
 }

--- a/src/modules/webhook/webhookService.ts
+++ b/src/modules/webhook/webhookService.ts
@@ -1,14 +1,11 @@
 import { SpritzClient } from '../../lib/client'
+import { restRoute } from '../../rest/route'
 import type { PathRequestBody, PathResponse } from '../../rest/types'
 
 type RestCreateWebhookRequest = PathRequestBody<'/v1/integrator/webhooks', 'post'>
 type RestIntegratorWebhook = PathResponse<'/v1/integrator/webhooks', 'post'>
 type RestIntegratorWebhookList = PathResponse<'/v1/integrator/webhooks', 'get'>
-type RestDeletedIntegratorWebhook = PathResponse<'/v1/integrator/webhooks/{webhookId}', 'delete'>
-type RestUpdateWebhookRequest = PathRequestBody<'/v1/integrator/webhooks/{webhookId}', 'patch'>
 type RestUpdatedIntegratorWebhook = PathResponse<'/v1/integrator/webhooks/{webhookId}', 'patch'>
-type RestUpdateWebhookSecretRequest = PathRequestBody<'/v1/integrator/webhook-secret', 'post'>
-type RestUpdateWebhookSecretResponse = PathResponse<'/v1/integrator/webhook-secret', 'post'>
 
 export type WebhookEvent = NonNullable<RestCreateWebhookRequest['events']>[number]
 
@@ -62,46 +59,38 @@ export class WebhookService {
     }
 
     public async create(args: CreateWebhookParams) {
-        const webhook = await this.client.restApi<RestIntegratorWebhook, RestCreateWebhookRequest>({
-            method: 'post',
-            path: '/v1/integrator/webhooks',
-            body: args,
-        })
+        const webhook = await this.client.restApi(
+            restRoute('/v1/integrator/webhooks', 'post', {
+                body: args,
+            })
+        )
 
         return normalizeWebhook(webhook)
     }
 
     public async update(webhookId: string, args: UpdateWebhookParams) {
-        const webhook = await this.client.restApi<
-            RestUpdatedIntegratorWebhook,
-            RestUpdateWebhookRequest
-        >({
-            method: 'patch',
-            path: `/v1/integrator/webhooks/${encodeURIComponent(webhookId)}`,
-            body: args,
-        })
+        const webhook = await this.client.restApi(
+            restRoute('/v1/integrator/webhooks/{webhookId}', 'patch', {
+                params: { webhookId },
+                body: args,
+            })
+        )
 
         return normalizeWebhook(webhook)
     }
 
     public async updateWebhookSecret(secret: string) {
-        const response = await this.client.restApi<
-            RestUpdateWebhookSecretResponse,
-            RestUpdateWebhookSecretRequest
-        >({
-            method: 'post',
-            path: '/v1/integrator/webhook-secret',
-            body: { secret },
-        })
+        const response = await this.client.restApi(
+            restRoute('/v1/integrator/webhook-secret', 'post', {
+                body: { secret },
+            })
+        )
 
         return { success: response.secretConfigured }
     }
 
     public async list() {
-        const webhooks = await this.client.restApi<RestIntegratorWebhookList>({
-            method: 'get',
-            path: '/v1/integrator/webhooks',
-        })
+        const webhooks = await this.client.restApi(restRoute('/v1/integrator/webhooks', 'get'))
 
         return webhooks.map(normalizeWebhook)
     }
@@ -111,10 +100,11 @@ export class WebhookService {
             .then((webhooks) => webhooks.find((webhook) => webhook.id === webhookId))
             .catch(() => undefined)
 
-        await this.client.restApi<RestDeletedIntegratorWebhook>({
-            method: 'delete',
-            path: `/v1/integrator/webhooks/${encodeURIComponent(webhookId)}`,
-        })
+        await this.client.restApi(
+            restRoute('/v1/integrator/webhooks/{webhookId}', 'delete', {
+                params: { webhookId },
+            })
+        )
 
         return (
             existingWebhook ?? {

--- a/src/rest/route.test.ts
+++ b/src/rest/route.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { buildRestPath, normalizeRestQuery, restRoute, type RestRoute } from './route'
+import {
+    buildRestPath,
+    normalizeRestQuery,
+    restRoute,
+    type RestRoute,
+    type RestRouteOptions,
+} from './route'
+import type { PathRequestBody } from './types'
 
 describe('REST route builder', () => {
     it('builds paths with encoded path parameters', () => {
@@ -60,5 +67,16 @@ describe('REST route builder', () => {
         expectTypeOf(route).toMatchTypeOf<
             RestRoute<'/v1/funding-sources/{fundingSourceId}', 'get'>
         >()
+    })
+
+    it('keeps required request bodies required at the route seam', () => {
+        type CreateDepositBody = PathRequestBody<'/v1/deposits/direct', 'post'>
+        type CreateDepositOptions = RestRouteOptions<'/v1/deposits/direct', 'post'>
+
+        expectTypeOf<CreateDepositOptions>().toMatchTypeOf<{ body: CreateDepositBody }>()
+    })
+
+    it('allows omitting bodies that the generated contract accepts as empty objects', () => {
+        expectTypeOf<{}>().toMatchTypeOf<RestRouteOptions<'/v1/bank-accounts/link-token', 'post'>>()
     })
 })

--- a/src/rest/route.test.ts
+++ b/src/rest/route.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { buildRestPath, normalizeRestQuery, restRoute, type RestRoute } from './route'
+
+describe('REST route builder', () => {
+    it('builds paths with encoded path parameters', () => {
+        expect(
+            restRoute('/v1/funding-sources/{fundingSourceId}', 'get', {
+                params: { fundingSourceId: 'fs_123/with space' },
+            })
+        ).toEqual({
+            method: 'get',
+            path: '/v1/funding-sources/fs_123%2Fwith%20space',
+        })
+    })
+
+    it('rejects missing path parameters', () => {
+        expect(() => buildRestPath('/v1/funding-sources/{fundingSourceId}')).toThrow(
+            'Missing path parameter: fundingSourceId'
+        )
+    })
+
+    it('normalizes scalar query parameters', () => {
+        expect(
+            normalizeRestQuery({
+                limit: 50,
+                cursor: undefined,
+                lossOnly: 'true',
+                includeDisabled: false,
+            })
+        ).toEqual({
+            limit: 50,
+            lossOnly: 'true',
+            includeDisabled: false,
+        })
+    })
+
+    it('rejects unsupported query parameter values', () => {
+        expect(() => normalizeRestQuery({ ids: ['one', 'two'] })).toThrow(
+            'Unsupported query parameter value for ids'
+        )
+    })
+
+    it('includes request bodies unchanged', () => {
+        expect(
+            restRoute('/v1/sandbox/bypass-kyc', 'post', {
+                body: { country: 'US' },
+            })
+        ).toEqual({
+            method: 'post',
+            path: '/v1/sandbox/bypass-kyc',
+            body: { country: 'US' },
+        })
+    })
+
+    it('binds the generated operation type to the route', () => {
+        const route = restRoute('/v1/funding-sources/{fundingSourceId}', 'get', {
+            params: { fundingSourceId: 'fs_123' },
+        })
+
+        expectTypeOf(route).toMatchTypeOf<
+            RestRoute<'/v1/funding-sources/{fundingSourceId}', 'get'>
+        >()
+    })
+})

--- a/src/rest/route.ts
+++ b/src/rest/route.ts
@@ -8,6 +8,9 @@ import type {
 } from './types'
 
 type IsNever<T> = [T] extends [never] ? true : false
+type EmptyObject = Record<string, never>
+type CanOmitBody<T> = EmptyObject extends T ? true : false
+type SupportedRestQuery<T> = IsNever<T> extends true ? never : T extends RestQuery ? T : never
 
 type RestPathParamsOption<P extends RestPath, M extends RestMethod<P>> =
     IsNever<PathParams<P, M>> extends true ? { params?: never } : { params: PathParams<P, M> }
@@ -15,13 +18,23 @@ type RestPathParamsOption<P extends RestPath, M extends RestMethod<P>> =
 type RestBodyOption<P extends RestPath, M extends RestMethod<P>> =
     IsNever<PathRequestBody<P, M>> extends true
         ? { body?: never }
-        : { body?: PathRequestBody<P, M> }
+        : CanOmitBody<PathRequestBody<P, M>> extends true
+          ? { body?: PathRequestBody<P, M> }
+          : { body: PathRequestBody<P, M> }
 
 type RestQueryOption<P extends RestPath, M extends RestMethod<P>> =
-    IsNever<PathQuery<P, M>> extends true ? { query?: never } : { query?: PathQuery<P, M> }
+    IsNever<SupportedRestQuery<PathQuery<P, M>>> extends true
+        ? { query?: never }
+        : { query?: SupportedRestQuery<PathQuery<P, M>> }
 
 type RestRouteNeedsOptions<P extends RestPath, M extends RestMethod<P>> =
-    IsNever<PathParams<P, M>> extends false ? true : false
+    IsNever<PathParams<P, M>> extends false
+        ? true
+        : IsNever<PathRequestBody<P, M>> extends true
+          ? false
+          : CanOmitBody<PathRequestBody<P, M>> extends true
+            ? false
+            : true
 
 export type RestQueryValue = string | number | boolean | undefined
 export type RestQuery = Record<string, RestQueryValue>
@@ -87,7 +100,7 @@ export function restRoute<P extends RestPath, M extends RestMethod<P>>(
 ): RestRoute<P, M> {
     const params = pathParamsAsRecord(options?.params)
     const routePath = buildRestPath(path, params)
-    const query = normalizeRestQuery(options?.query as Record<string, unknown> | undefined)
+    const query = normalizeRestQuery(options?.query)
     const body = options?.body as PathRequestBody<P, M> | undefined
 
     return {

--- a/src/rest/route.ts
+++ b/src/rest/route.ts
@@ -1,0 +1,101 @@
+import type {
+    HttpMethod,
+    PathParams,
+    PathQuery,
+    PathRequestBody,
+    RestMethod,
+    RestPath,
+} from './types'
+
+type IsNever<T> = [T] extends [never] ? true : false
+
+type RestPathParamsOption<P extends RestPath, M extends RestMethod<P>> =
+    IsNever<PathParams<P, M>> extends true ? { params?: never } : { params: PathParams<P, M> }
+
+type RestBodyOption<P extends RestPath, M extends RestMethod<P>> =
+    IsNever<PathRequestBody<P, M>> extends true
+        ? { body?: never }
+        : { body?: PathRequestBody<P, M> }
+
+type RestQueryOption<P extends RestPath, M extends RestMethod<P>> =
+    IsNever<PathQuery<P, M>> extends true ? { query?: never } : { query?: PathQuery<P, M> }
+
+type RestRouteNeedsOptions<P extends RestPath, M extends RestMethod<P>> =
+    IsNever<PathParams<P, M>> extends false ? true : false
+
+export type RestQueryValue = string | number | boolean | undefined
+export type RestQuery = Record<string, RestQueryValue>
+
+export type RestRouteOptions<P extends RestPath, M extends RestMethod<P>> = RestPathParamsOption<
+    P,
+    M
+> &
+    RestBodyOption<P, M> &
+    RestQueryOption<P, M>
+
+export type RestRoute<P extends RestPath = RestPath, M extends RestMethod<P> = RestMethod<P>> = {
+    method: M
+    path: string
+    body?: PathRequestBody<P, M>
+    query?: RestQuery
+}
+
+function pathParamsAsRecord(params: unknown): Record<string, unknown> | undefined {
+    if (!params || typeof params !== 'object') return undefined
+    return params as Record<string, unknown>
+}
+
+export function buildRestPath(path: string, params?: Record<string, unknown>) {
+    return path.replace(/\{([^}]+)\}/g, (_, key: string) => {
+        if (!params || !(key in params)) {
+            throw new Error(`Missing path parameter: ${key}`)
+        }
+
+        const value = params[key]
+        if (value === undefined || value === null) {
+            throw new Error(`Missing path parameter: ${key}`)
+        }
+
+        return encodeURIComponent(String(value))
+    })
+}
+
+export function normalizeRestQuery(query?: Record<string, unknown>): RestQuery | undefined {
+    if (!query) return undefined
+
+    const entries: [string, string | number | boolean][] = []
+
+    for (const [key, value] of Object.entries(query)) {
+        if (value === undefined) continue
+
+        if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+            throw new Error(`Unsupported query parameter value for ${key}`)
+        }
+
+        entries.push([key, value])
+    }
+
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined
+}
+
+export function restRoute<P extends RestPath, M extends RestMethod<P>>(
+    path: P,
+    method: M,
+    ...[options]: RestRouteNeedsOptions<P, M> extends true
+        ? [options: RestRouteOptions<P, M>]
+        : [options?: RestRouteOptions<P, M>]
+): RestRoute<P, M> {
+    const params = pathParamsAsRecord(options?.params)
+    const routePath = buildRestPath(path, params)
+    const query = normalizeRestQuery(options?.query as Record<string, unknown> | undefined)
+    const body = options?.body as PathRequestBody<P, M> | undefined
+
+    return {
+        method,
+        path: routePath,
+        ...(body !== undefined ? { body } : {}),
+        ...(query ? { query } : {}),
+    }
+}
+
+export type { HttpMethod, RestMethod, RestPath }

--- a/src/rest/types.ts
+++ b/src/rest/types.ts
@@ -1,43 +1,42 @@
 import type { paths } from './__generated__/api'
 
-type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete'
+export type RestPath = keyof paths
+export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete'
+export type RestMethod<P extends RestPath> = HttpMethod & keyof paths[P]
 
-type Extract200<
-    P extends keyof paths,
-    M extends HttpMethod & keyof paths[P],
-> = paths[P][M] extends {
+type Extract200<P extends RestPath, M extends RestMethod<P>> = paths[P][M] extends {
     responses: { 200: { content: { 'application/json': infer R } } }
 }
     ? R
     : never
 
-type Extract201<
-    P extends keyof paths,
-    M extends HttpMethod & keyof paths[P],
-> = paths[P][M] extends {
+type Extract201<P extends RestPath, M extends RestMethod<P>> = paths[P][M] extends {
     responses: { 201: { content: { 'application/json': infer R } } }
 }
     ? R
     : never
 
 /** Extract the success (200/201) JSON response body for a path + method */
-export type PathResponse<P extends keyof paths, M extends HttpMethod & keyof paths[P]> =
+export type PathResponse<P extends RestPath, M extends RestMethod<P>> =
     Extract200<P, M> extends never ? Extract201<P, M> : Extract200<P, M> | Extract201<P, M>
 
 /** Extract the JSON request body for a path + method */
-export type PathRequestBody<
-    P extends keyof paths,
-    M extends HttpMethod & keyof paths[P],
-> = paths[P][M] extends { requestBody: { content: { 'application/json': infer B } } } ? B : never
+export type PathRequestBody<P extends RestPath, M extends RestMethod<P>> = paths[P][M] extends {
+    requestBody: { content: { 'application/json': infer B } }
+}
+    ? B
+    : never
 
 /** Extract query parameters for a path + method */
-export type PathQuery<
-    P extends keyof paths,
-    M extends HttpMethod & keyof paths[P],
-> = paths[P][M] extends { parameters: { query?: infer Q } } ? Q : never
+export type PathQuery<P extends RestPath, M extends RestMethod<P>> = paths[P][M] extends {
+    parameters: { query?: infer Q }
+}
+    ? Q
+    : never
 
 /** Extract path parameters for a path + method */
-export type PathParams<
-    P extends keyof paths,
-    M extends HttpMethod & keyof paths[P],
-> = paths[P][M] extends { parameters: { path: infer PP } } ? PP : never
+export type PathParams<P extends RestPath, M extends RestMethod<P>> = paths[P][M] extends {
+    parameters: { path: infer PP }
+}
+    ? PP
+    : never


### PR DESCRIPTION
## Summary

- Add `restRoute` to centralize REST path parameter encoding, scalar query normalization, and OpenAPI operation typing.
- Keep `SpritzClient.restApi()` compatible with the existing object-call shape while adding typed-route inference.
- Migrate REST-backed SDK modules to the shared route seam without changing their public methods or return shapes.
- Add a patch changeset for `@spritz-finance/api-client`, which changesets reports as `0.8.2` from the current `0.8.1`.

## Validation

- `yarn changeset status --verbose`
- `yarn agent:check`